### PR TITLE
datachannel の改善

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,7 +23,7 @@
     - @Hexa
 - [CHANGE] Ayame が isExistUser を送ってくる場合のみ接続できるようにする
     - @Hexa
-- [FIX] bye 受信時に on('disconnect') コールバックが発火するように修正する
+- [FIX] bye を受信した場合にも on('disconnect') コールバックが発火するように修正する
     - @Hexa
 
 ## 2020.1.2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,21 @@
 
 ## develop
 
+- [CHANGE] addDataChannel, sendData を削除する
+    - @Hexa
+- [CHANGE] on('data') コールバックを削除する
+    - @Hexa
+- [ADD] createDataChannel を追加する
+    - @Hexa
+- [ADD] on('datachannel') コールバックを追加する
+    - @Hexa
+- [FIX] offer 側の場合のみ RTCDataChannel オブジェクトを作成するように修正する
+    - @Hexa
+- [CHANGE] Ayame が isExistUser を送ってくる場合のみ接続できるようにする
+    - @Hexa
+- [FIX] bye 受信時に on('disconnect') コールバックが発火するように修正する
+    - @Hexa
+
 ## 2020.1.2
 
 - [FIX] 依存ライブラリを最新にする

--- a/src/connection/base.ts
+++ b/src/connection/base.ts
@@ -155,18 +155,11 @@ class ConnectionBase {
                   this._traceLog('iceServers=>', message.iceServers);
                   this._pcConfig.iceServers = message.iceServers;
                 }
-                if (message.isExistUser === undefined) {
-                  if (!this._pc) {
-                    this._createPeerConnection();
-                  }
+                this._traceLog('isExistUser=>', message.isExistUser);
+                this._isExistUser = message.isExistUser;
+                this._createPeerConnection();
+                if (this._isExistUser === true) {
                   await this._sendOffer();
-                } else {
-                  this._traceLog('isExistUser=>', message.isExistUser);
-                  this._isExistUser = message.isExistUser;
-                  this._createPeerConnection();
-                  if (this._isExistUser === true) {
-                    await this._sendOffer();
-                  }
                 }
                 return resolve();
               } else if (message.type === 'reject') {

--- a/src/connection/base.ts
+++ b/src/connection/base.ts
@@ -147,7 +147,6 @@ class ConnectionBase {
                 this._sendWs({ type: 'pong' });
               } else if (message.type === 'bye') {
                 this._callbacks.bye(event);
-                await this._disconnect();
                 return resolve();
               } else if (message.type === 'accept') {
                 this.authzMetadata = message.authzMetadata;

--- a/src/connection/base.ts
+++ b/src/connection/base.ts
@@ -287,8 +287,8 @@ class ConnectionBase {
     }
   }
 
-  async _createDataChannel(label: string, options: RTCDataChannelInit | undefined): Promise<RTCDataChannel> {
-    return new Promise<RTCDataChannel>((resolve, reject) => {
+  async _createDataChannel(label: string, options: RTCDataChannelInit | undefined): Promise<RTCDataChannel | null> {
+    return new Promise<RTCDataChannel | null>((resolve, reject) => {
       if (!this._pc) return reject('PeerConnection Does Not Ready');
       if (this._isOffer) return reject('PeerConnection Has Local Offer');
       let dataChannel = this._findDataChannel(label);
@@ -315,6 +315,7 @@ class ConnectionBase {
         this._dataChannels.push(dataChannel);
         return resolve(dataChannel);
       }
+      return resolve(null);
     });
   }
 

--- a/src/connection/index.ts
+++ b/src/connection/index.ts
@@ -50,12 +50,12 @@ class Connection extends ConnectionBase {
    * @desc Datachannel を作成します。
    * @param {string} label - dataChannel の label
    * @param {RTCDataChannelInit|undefined} [options=undefined] - dataChannel の init オプション
-   * @return {RTCDataChannel} dataChannel
+   * @return {RTCDataChannel|null} 生成されたデータチャネル
    */
   public async createDataChannel(
     label: string,
     options: RTCDataChannelInit | undefined = undefined
-  ): Promise<RTCDataChannel> {
+  ): Promise<RTCDataChannel | null> {
     return await this._createDataChannel(label, options);
   }
 

--- a/src/connection/index.ts
+++ b/src/connection/index.ts
@@ -47,12 +47,13 @@ class Connection extends ConnectionBase {
   }
 
   /**
-   * @desc Datachannel を追加します。
+   * @desc Datachannel を作成します。
    * @param {string} label - dataChannel の label
    * @param {RTCDataChannelInit|undefined} [options=undefined] - dataChannel の init オプション
+   * @return {RTCDataChannel} dataChannel
    */
-  public async addDataChannel(label: string, options: RTCDataChannelInit | undefined = undefined): Promise<void> {
-    await this._addDataChannel(label, options);
+  public async createDataChannel(label: string, options: RTCDataChannelInit | undefined = undefined): Promise<RTCDataChannel> {
+    return await this._createDataChannel(label, options);
   }
 
   /**
@@ -66,21 +67,6 @@ class Connection extends ConnectionBase {
       await this._closeDataChannel(dataChannel);
     } else {
       throw new Error('data channel is not exist or open');
-    }
-  }
-
-  /**
-   * @desc Datachannel でデータを送信します。
-   * @param {any} params - 送信するデータ
-   * @param {string} [label='dataChannel'] - 指定する dataChannel の label
-   */
-  public sendData(params: any, label = 'dataChannel'): void {
-    this._traceLog('datachannel sendData=>', params);
-    const dataChannel = this._findDataChannel(label);
-    if (dataChannel && dataChannel.readyState === 'open') {
-      dataChannel.send(params);
-    } else {
-      throw new Error('datachannel is not open');
     }
   }
 

--- a/src/connection/index.ts
+++ b/src/connection/index.ts
@@ -52,7 +52,10 @@ class Connection extends ConnectionBase {
    * @param {RTCDataChannelInit|undefined} [options=undefined] - dataChannel の init オプション
    * @return {RTCDataChannel} dataChannel
    */
-  public async createDataChannel(label: string, options: RTCDataChannelInit | undefined = undefined): Promise<RTCDataChannel> {
+  public async createDataChannel(
+    label: string,
+    options: RTCDataChannelInit | undefined = undefined
+  ): Promise<RTCDataChannel> {
     return await this._createDataChannel(label, options);
   }
 

--- a/test/datachannel.html
+++ b/test/datachannel.html
@@ -27,24 +27,37 @@
         let conn = null;
         const options = Ayame.defaultOptions;
         options.clientId = clientId ? clientId : options.clientId;
-        const channel = 'dataChannel';
+        const label = 'dataChannel';
+        let dataChannel = null;
         const startConn = async () => {
           conn = Ayame.connection(signalingUrl, roomId, options, true);
-          conn.on('open', (e) => {
-            conn.addDataChannel(channel);
+          conn.on('open', async (e) => {
+            dataChannel = await conn.createDataChannel(label);
+            if (dataChannel) {
+              dataChannel.onmessage = onMessage;
+            }
           });
-          conn.on('data', (e) => {
-            messages = messages ? (messages + '\n' + e.data) : e.data;
-            document.querySelector("#messages").value = messages;
+          conn.on('datachannel', (channel) => {
+            if (!dataChannel) {
+              dataChannel = channel;
+              dataChannel.onmessage = onMessage;
+            }
           });
           await conn.connect(null);
         };
         const sendData = () => {
           const data = document.querySelector("#sendDataInput").value;
-          conn.sendData(data);
+          if (dataChannel && dataChannel.readyState === 'open') {
+            dataChannel.send(data);
+          }
         };
         document.querySelector("#roomIdInput").value = roomId;
         document.querySelector("#clientIdInput").value = options.clientId;
+
+        function onMessage(e) {
+          messages = messages ? (messages + '\n' + e.data) : e.data;
+          document.querySelector("#messages").value = messages;
+        }
       </script>
   </body>
 </html>

--- a/test/datachannel.html
+++ b/test/datachannel.html
@@ -43,6 +43,9 @@
               dataChannel.onmessage = onMessage;
             }
           });
+          conn.on('disconnect', () => {
+            dataChannel = null;
+          });
           await conn.connect(null);
         };
         const sendData = () => {

--- a/test/multi_datachannel.html
+++ b/test/multi_datachannel.html
@@ -39,21 +39,34 @@
         const options = Ayame.defaultOptions;
         let messagesA = null;
         let messagesB = null;
-        const channel = 'dataChannel';
-        const anotherChannel = 'anotherChannel';
+        const label = 'dataChannel';
+        const anotherLabel = 'anotherChannel';
         options.clientId = clientId ? clientId : options.clientId;
         conn = Ayame.connection(signalingUrl, roomId, options, true);
-        conn.on('open', (e) => {
-          conn.addDataChannel(channel);
-          conn.addDataChannel(anotherChannel);
+        let dataChannel = null;
+        let anotherDataChannel = null;
+        conn.on('open', async (e) => {
+          dataChannel = await conn.createDataChannel(label);
+          if (dataChannel) {
+            dataChannel.onmessage = onMessageA;
+          }
+          anotherDataChannel = await conn.createDataChannel(anotherLabel);
+          if (anotherDataChannel) {
+            anotherDataChannel.onmessage = onMessageB;
+          }
         });
-        conn.on('data', (e) => {
-          if (e.label == anotherChannel) {
-            messagesB = messagesB ? (messagesB + '\n' + e.data) : e.data;
-            document.querySelector("#messagesB").value = messagesB;
-          } else {
-            messagesA = messagesA ? (messagesA + '\n' + e.data) : e.data;
-            document.querySelector("#messagesA").value = messagesA;
+        conn.on('datachannel', (channel) => {
+          console.log('=== datachannel ===');
+          if (channel.label === label) {
+            if (!dataChannel) {
+              dataChannel = channel;
+              dataChannel.onmessage = onMessageA;
+            }
+          } else if (channel.label === anotherLabel) {
+            if (!anotherDataChannel) {
+              anotherDataChannel = channel;
+              anotherDataChannel.onmessage = onMessageB;
+            }
           }
         });
         const startConn = async () => {
@@ -61,14 +74,27 @@
         };
         const sendDataA = () => {
           const data = document.querySelector("#sendDataInputA").value;
-          conn.sendData(data);
+          if (dataChannel && dataChannel.readyState === 'open') {
+            dataChannel.send(data);
+          }
         };
         const sendDataB = () => {
           const data = document.querySelector("#sendDataInputB").value;
-          conn.sendData(data, anotherChannel);
+          if (anotherDataChannel && anotherDataChannel.readyState === 'open') {
+            anotherDataChannel.send(data);
+          }
         };
         document.querySelector("#roomIdInput").value = roomId;
         document.querySelector("#clientIdInput").value = options.clientId;
+
+        function onMessageA(e) {
+          messagesA = messagesA ? (messagesA + '\n' + e.data) : e.data;
+          document.querySelector("#messagesA").value = messagesA;
+        }
+        function onMessageB(e) {
+          messagesB = messagesB ? (messagesB + '\n' + e.data) : e.data;
+          document.querySelector("#messagesB").value = messagesB;
+        }
       </script>
   </body>
 </html>

--- a/test/multi_datachannel.html
+++ b/test/multi_datachannel.html
@@ -56,7 +56,6 @@
           }
         });
         conn.on('datachannel', (channel) => {
-          console.log('=== datachannel ===');
           if (channel.label === label) {
             if (!dataChannel) {
               dataChannel = channel;
@@ -68,6 +67,10 @@
               anotherDataChannel.onmessage = onMessageB;
             }
           }
+        });
+        conn.on('disconnect', () => {
+          dataChannel = null;
+          anotherDataChannel = null;
         });
         const startConn = async () => {
           await conn.connect(null);

--- a/test/multi_datachannel.html
+++ b/test/multi_datachannel.html
@@ -68,6 +68,10 @@
             }
           }
         });
+        conn.on('disconnect', () => {
+          dataChannel = null;
+          anotherDataChannel = null;
+        });
         const startConn = async () => {
           await conn.connect(null);
         };

--- a/test/multi_datachannel.html
+++ b/test/multi_datachannel.html
@@ -68,10 +68,6 @@
             }
           }
         });
-        conn.on('disconnect', () => {
-          dataChannel = null;
-          anotherDataChannel = null;
-        });
         const startConn = async () => {
           await conn.connect(null);
         };

--- a/test/multi_datachannel.html
+++ b/test/multi_datachannel.html
@@ -72,16 +72,10 @@
           await conn.connect(null);
         };
         const sendDataA = () => {
-          const data = document.querySelector("#sendDataInputA").value;
-          if (dataChannel && dataChannel.readyState === 'open') {
-            dataChannel.send(data);
-          }
+          sendData("#sendDataInputA", dataChannel)
         };
         const sendDataB = () => {
-          const data = document.querySelector("#sendDataInputB").value;
-          if (anotherDataChannel && anotherDataChannel.readyState === 'open') {
-            anotherDataChannel.send(data);
-          }
+          sendData("#sendDataInputB", anotherDataChannel)
         };
         document.querySelector("#roomIdInput").value = roomId;
         document.querySelector("#clientIdInput").value = options.clientId;
@@ -93,6 +87,12 @@
         function onMessageB(e) {
           messagesB = messagesB ? (messagesB + '\n' + e.data) : e.data;
           document.querySelector("#messagesB").value = messagesB;
+        }
+        function sendData(id, channel) {
+          const data = document.querySelector(id).value;
+          if (channel && channel.readyState === 'open') {
+            channel.send(data);
+          }
         }
       </script>
   </body>


### PR DESCRIPTION
datachannel の改善内容です

- RTCDataChannel オブジェクトをそのまま利用するように変更
  - RTCDataChannel オブジェクトを返す createDataChannel() を追加
  - RTCDataChannel オブジェクトをそのまま利用するため、不要になった addDataChannel()、 sendData()、on('data') コールバックを削除
  - answer 側の datachannel イベントのための on('datachannel') コールバックの追加
- offer, answer の両方で RTCDataChannel オブジェクトを作成していたので、これを offer 側のみの作成に修正
- Ayame が isExistUser を送ってくる場合のみ接続できるように変更
- bye を受信した場合にも on('disconnect') コールバックが発火するように修正