### PR TITLE
Feature/fix codec preferences

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,16 +3,15 @@ name: CI
 on:
   push:
     branches:
-      - master
       - develop
       - "feature/*"
       - "releases/*"
 jobs:
-  build:
+  ci_job:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: ["20", "22", "23"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  deploy_job:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -41,7 +41,7 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
   deploy:
-    needs: build
+    needs: deploy_job
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -12,12 +12,12 @@ on:
     - cron: "0 2 * * 1-5"
 
 jobs:
-  e2e-test:
+  e2e_test_job:
     timeout-minutes: 10
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        node: ["20", "22"]
+        node-version: ["20", "22", "23"]
         # browser: ["chromium", "firefox", "webkit"]
         browser: ["chromium"]
     env:
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node }}
+          node-version: ${{ matrix.node-version }}
       - uses: pnpm/action-setup@v4
       - run: pnpm --version
       - run: pnpm install
@@ -36,4 +36,4 @@ jobs:
       - run: pnpm exec playwright install ${{ matrix.browser }} --with-deps
       - run: pnpm exec playwright test --project=${{ matrix.browser }}
         env:
-          VITE_AYAME_ROOM_NAME: ${{ matrix.node }}
+          VITE_AYAME_ROOM_NAME: ${{ matrix.node-version }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,34 +15,38 @@
   - @voluntas
 - [CHANGE] `removestream` は利用されていないため廃止する
   - @voluntas
+- [UPDATE] `setCodecPreferences` を利用してコーデックを指定できるようにする
+  - @voluntas
 - [ADD] `AyameAddStreamEvent` を追加する
   - `addstream` コールバックのイベント型を `AyameAddStreamEvent` として追加する
   - @voluntas
-- [ADD] standalone モードに対応する
-  - options に standalone を追加する
-  - standalone モード時は、接続完了時に ayame に type: connected を送信する
-  - standalone モード時は、ayame から WebSocket 接続が切断されても、ブラウザ間の接続は維持する
+- [ADD] `standalone` モードに対応する
+  - `options` に `standalone` を追加する
+  - `standalone` モード時は、接続完了時に ayame に `type: connected` を送信する
+  - `standalone` モード時は、ayame から WebSocket 接続が切断されても、ブラウザ間の接続は維持する
   - @Hexa
-- [FIX] disconnect の処理が正常に動作しない問題を修正する
+- [FIX] `disconnect` の処理が正常に動作しない問題を修正する
   - @voluntas
 
 ### misc
 
 - [CHANGE] ConnectionBase を Connection へ変更する
   - @voluntas
-- [CHANGE] rollup から vite へ変更
+- [CHANGE] rollup から [Vite](https://vite.dev/) へ変更
   - @voluntas
-- [CHANGE] npm から pnpm に変更する
+- [CHANGE] npm から [pnpm](https://pnpm.io/) に変更
   - @voluntas
-- [CHANGE] eslint から biome へ変更
+- [CHANGE] eslint から [biome](https://biomejs.dev/) へ変更
   - @voluntas
-- [CHANGE] prettier から biome へ変更する
+- [CHANGE] prettier から [biome](https://biomejs.dev/) へ変更する
   - @voluntas
-- [CHANGE] GitHub Actions の node-version を 18 と 20 と 22 にする
+- [CHANGE] GitHub Actions の node-version を 20 と 22 にする
   - @voluntas
 - [UPDATE] ubuntu-latest から ubuntu-24.04 に変更する
   - @voluntas
-- [ADD] Ayame DevTools を追加
+- [ADD] 検証用の Ayame DevTools を追加
+  - @voluntas
+- [ADD] Playwright と Ayame DevTools を利用した E2E テストを追加
   - @voluntas
 
 ## 2022.1

--- a/devtools/src/components/AudioCodecMimeType.tsx
+++ b/devtools/src/components/AudioCodecMimeType.tsx
@@ -23,7 +23,7 @@ const VideoCodecMimeType: React.FC = () => {
   }
 
   return (
-    <select onChange={handleChange} value={audioCodecMimeType}>
+    <select onChange={handleChange} value={audioCodecMimeType} data-testid="audio-codec-mime-type">
       <option value="undefined">未指定</option>
       {codecs.map((mimeType) => (
         <option key={mimeType} value={mimeType}>

--- a/devtools/src/components/VideoCodecMimeType.tsx
+++ b/devtools/src/components/VideoCodecMimeType.tsx
@@ -23,7 +23,7 @@ const VideoCodecMimeType: React.FC = () => {
   }
 
   return (
-    <select onChange={handleChange} value={videoCodecMimeType}>
+    <select onChange={handleChange} value={videoCodecMimeType} data-testid="video-codec-mime-type">
       <option value="undefined">未指定</option>
       {codecs.map((mimeType) => (
         <option key={mimeType} value={mimeType}>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         version: 6.1.0(@types/node@22.13.4)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0)
       vite-plugin-dts:
         specifier: 4.5.0
-        version: 4.5.0(@types/node@22.13.4)(rollup@4.34.6)(typescript@5.7.3)(vite@6.1.0(@types/node@22.13.4)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0))
+        version: 4.5.0(@types/node@22.13.4)(rollup@4.34.8)(typescript@5.7.3)(vite@6.1.0(@types/node@22.13.4)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0))
 
   devtools:
     dependencies:
@@ -72,12 +72,12 @@ packages:
     resolution: {integrity: sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/core@7.26.8':
-    resolution: {integrity: sha512-l+lkXCHS6tQEc5oUpK28xBOZ6+HwaH7YwoYQbLFiYb4nS2/l1tKnZEtEWkD0GuiYdvArf9qBS0XlQGXzPMsNqQ==}
+  '@babel/core@7.26.9':
+    resolution: {integrity: sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@7.26.8':
-    resolution: {integrity: sha512-ef383X5++iZHWAXX0SXQR6ZyQhw/0KtTkrTz61WXRhFM6dhpHulO/RJz79L8S6ugZHJkOOkUrUdxgdF2YiPFnA==}
+  '@babel/generator@7.26.9':
+    resolution: {integrity: sha512-kEWdzjOAUMW4hAyrzJ0ZaTOu9OmpyDIQicIh0zg0EEcEkYXZb2TjtBhnHi2ViX7PKwZqF4xwqfAm299/QMP3lg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-compilation-targets@7.26.5':
@@ -110,12 +110,12 @@ packages:
     resolution: {integrity: sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helpers@7.26.7':
-    resolution: {integrity: sha512-8NHiL98vsi0mbPQmYAGWwfcFaOy4j2HY49fXJCfuDcdE7fMIsH9a7GdaeXpIBsbT7307WU8KCMp5pUVDNL4f9A==}
+  '@babel/helpers@7.26.9':
+    resolution: {integrity: sha512-Mz/4+y8udxBKdmzt/UjPACs4G3j5SshJJEFFKxlCGPydG4JAHXxjWjAwjd09tf6oINvl1VfMJo+nB7H2YKQ0dA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.26.8':
-    resolution: {integrity: sha512-TZIQ25pkSoaKEYYaHbbxkfL36GNsQ6iFiBbeuzAkLnXayKR1yP1zFe+NxuZWWsUyvt8icPU9CCq0sgWGXR1GEw==}
+  '@babel/parser@7.26.9':
+    resolution: {integrity: sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -131,16 +131,16 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/template@7.26.8':
-    resolution: {integrity: sha512-iNKaX3ZebKIsCvJ+0jd6embf+Aulaa3vNBqZ41kM7iTWjx5qzWKXGHiJUW3+nTpQ18SG11hdF8OAzKrpXkb96Q==}
+  '@babel/template@7.26.9':
+    resolution: {integrity: sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.26.8':
-    resolution: {integrity: sha512-nic9tRkjYH0oB2dzr/JoGIm+4Q6SuYeLEiIiZDwBscRMYFJ+tMAz98fuel9ZnbXViA2I0HVSSRRK8DW5fjXStA==}
+  '@babel/traverse@7.26.9':
+    resolution: {integrity: sha512-ZYW7L+pL8ahU5fXmNbPF+iZFHCv5scFak7MZ9bwaRPLUhHh7QQEMjZUg0HevihoqCM5iSYHN61EyCoZvqC+bxg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.26.8':
-    resolution: {integrity: sha512-eUuWapzEGWFEpHFxgEaBG8e3n6S8L3MSu0oda755rOfabWPnh0Our1AozNFVUxGFIhbKgd1ksprsoDGMinTOTA==}
+  '@babel/types@7.26.9':
+    resolution: {integrity: sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==}
     engines: {node: '>=6.9.0'}
 
   '@biomejs/biome@1.9.4':
@@ -479,98 +479,98 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.34.6':
-    resolution: {integrity: sha512-+GcCXtOQoWuC7hhX1P00LqjjIiS/iOouHXhMdiDSnq/1DGTox4SpUvO52Xm+div6+106r+TcvOeo/cxvyEyTgg==}
+  '@rollup/rollup-android-arm-eabi@4.34.8':
+    resolution: {integrity: sha512-q217OSE8DTp8AFHuNHXo0Y86e1wtlfVrXiAlwkIvGRQv9zbc6mE3sjIVfwI8sYUyNxwOg0j/Vm1RKM04JcWLJw==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.34.6':
-    resolution: {integrity: sha512-E8+2qCIjciYUnCa1AiVF1BkRgqIGW9KzJeesQqVfyRITGQN+dFuoivO0hnro1DjT74wXLRZ7QF8MIbz+luGaJA==}
+  '@rollup/rollup-android-arm64@4.34.8':
+    resolution: {integrity: sha512-Gigjz7mNWaOL9wCggvoK3jEIUUbGul656opstjaUSGC3eT0BM7PofdAJaBfPFWWkXNVAXbaQtC99OCg4sJv70Q==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.34.6':
-    resolution: {integrity: sha512-z9Ib+OzqN3DZEjX7PDQMHEhtF+t6Mi2z/ueChQPLS/qUMKY7Ybn5A2ggFoKRNRh1q1T03YTQfBTQCJZiepESAg==}
+  '@rollup/rollup-darwin-arm64@4.34.8':
+    resolution: {integrity: sha512-02rVdZ5tgdUNRxIUrFdcMBZQoaPMrxtwSb+/hOfBdqkatYHR3lZ2A2EGyHq2sGOd0Owk80oV3snlDASC24He3Q==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.34.6':
-    resolution: {integrity: sha512-PShKVY4u0FDAR7jskyFIYVyHEPCPnIQY8s5OcXkdU8mz3Y7eXDJPdyM/ZWjkYdR2m0izD9HHWA8sGcXn+Qrsyg==}
+  '@rollup/rollup-darwin-x64@4.34.8':
+    resolution: {integrity: sha512-qIP/elwR/tq/dYRx3lgwK31jkZvMiD6qUtOycLhTzCvrjbZ3LjQnEM9rNhSGpbLXVJYQ3rq39A6Re0h9tU2ynw==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.34.6':
-    resolution: {integrity: sha512-YSwyOqlDAdKqs0iKuqvRHLN4SrD2TiswfoLfvYXseKbL47ht1grQpq46MSiQAx6rQEN8o8URtpXARCpqabqxGQ==}
+  '@rollup/rollup-freebsd-arm64@4.34.8':
+    resolution: {integrity: sha512-IQNVXL9iY6NniYbTaOKdrlVP3XIqazBgJOVkddzJlqnCpRi/yAeSOa8PLcECFSQochzqApIOE1GHNu3pCz+BDA==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.34.6':
-    resolution: {integrity: sha512-HEP4CgPAY1RxXwwL5sPFv6BBM3tVeLnshF03HMhJYCNc6kvSqBgTMmsEjb72RkZBAWIqiPUyF1JpEBv5XT9wKQ==}
+  '@rollup/rollup-freebsd-x64@4.34.8':
+    resolution: {integrity: sha512-TYXcHghgnCqYFiE3FT5QwXtOZqDj5GmaFNTNt3jNC+vh22dc/ukG2cG+pi75QO4kACohZzidsq7yKTKwq/Jq7Q==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.34.6':
-    resolution: {integrity: sha512-88fSzjC5xeH9S2Vg3rPgXJULkHcLYMkh8faix8DX4h4TIAL65ekwuQMA/g2CXq8W+NJC43V6fUpYZNjaX3+IIg==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.34.8':
+    resolution: {integrity: sha512-A4iphFGNkWRd+5m3VIGuqHnG3MVnqKe7Al57u9mwgbyZ2/xF9Jio72MaY7xxh+Y87VAHmGQr73qoKL9HPbXj1g==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.34.6':
-    resolution: {integrity: sha512-wM4ztnutBqYFyvNeR7Av+reWI/enK9tDOTKNF+6Kk2Q96k9bwhDDOlnCUNRPvromlVXo04riSliMBs/Z7RteEg==}
+  '@rollup/rollup-linux-arm-musleabihf@4.34.8':
+    resolution: {integrity: sha512-S0lqKLfTm5u+QTxlFiAnb2J/2dgQqRy/XvziPtDd1rKZFXHTyYLoVL58M/XFwDI01AQCDIevGLbQrMAtdyanpA==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.34.6':
-    resolution: {integrity: sha512-9RyprECbRa9zEjXLtvvshhw4CMrRa3K+0wcp3KME0zmBe1ILmvcVHnypZ/aIDXpRyfhSYSuN4EPdCCj5Du8FIA==}
+  '@rollup/rollup-linux-arm64-gnu@4.34.8':
+    resolution: {integrity: sha512-jpz9YOuPiSkL4G4pqKrus0pn9aYwpImGkosRKwNi+sJSkz+WU3anZe6hi73StLOQdfXYXC7hUfsQlTnjMd3s1A==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.34.6':
-    resolution: {integrity: sha512-qTmklhCTyaJSB05S+iSovfo++EwnIEZxHkzv5dep4qoszUMX5Ca4WM4zAVUMbfdviLgCSQOu5oU8YoGk1s6M9Q==}
+  '@rollup/rollup-linux-arm64-musl@4.34.8':
+    resolution: {integrity: sha512-KdSfaROOUJXgTVxJNAZ3KwkRc5nggDk+06P6lgi1HLv1hskgvxHUKZ4xtwHkVYJ1Rep4GNo+uEfycCRRxht7+Q==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.34.6':
-    resolution: {integrity: sha512-4Qmkaps9yqmpjY5pvpkfOerYgKNUGzQpFxV6rnS7c/JfYbDSU0y6WpbbredB5cCpLFGJEqYX40WUmxMkwhWCjw==}
+  '@rollup/rollup-linux-loongarch64-gnu@4.34.8':
+    resolution: {integrity: sha512-NyF4gcxwkMFRjgXBM6g2lkT58OWztZvw5KkV2K0qqSnUEqCVcqdh2jN4gQrTn/YUpAcNKyFHfoOZEer9nwo6uQ==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.34.6':
-    resolution: {integrity: sha512-Zsrtux3PuaxuBTX/zHdLaFmcofWGzaWW1scwLU3ZbW/X+hSsFbz9wDIp6XvnT7pzYRl9MezWqEqKy7ssmDEnuQ==}
+  '@rollup/rollup-linux-powerpc64le-gnu@4.34.8':
+    resolution: {integrity: sha512-LMJc999GkhGvktHU85zNTDImZVUCJ1z/MbAJTnviiWmmjyckP5aQsHtcujMjpNdMZPT2rQEDBlJfubhs3jsMfw==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.34.6':
-    resolution: {integrity: sha512-aK+Zp+CRM55iPrlyKiU3/zyhgzWBxLVrw2mwiQSYJRobCURb781+XstzvA8Gkjg/hbdQFuDw44aUOxVQFycrAg==}
+  '@rollup/rollup-linux-riscv64-gnu@4.34.8':
+    resolution: {integrity: sha512-xAQCAHPj8nJq1PI3z8CIZzXuXCstquz7cIOL73HHdXiRcKk8Ywwqtx2wrIy23EcTn4aZ2fLJNBB8d0tQENPCmw==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.34.6':
-    resolution: {integrity: sha512-WoKLVrY9ogmaYPXwTH326+ErlCIgMmsoRSx6bO+l68YgJnlOXhygDYSZe/qbUJCSiCiZAQ+tKm88NcWuUXqOzw==}
+  '@rollup/rollup-linux-s390x-gnu@4.34.8':
+    resolution: {integrity: sha512-DdePVk1NDEuc3fOe3dPPTb+rjMtuFw89gw6gVWxQFAuEqqSdDKnrwzZHrUYdac7A7dXl9Q2Vflxpme15gUWQFA==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.34.6':
-    resolution: {integrity: sha512-Sht4aFvmA4ToHd2vFzwMFaQCiYm2lDFho5rPcvPBT5pCdC+GwHG6CMch4GQfmWTQ1SwRKS0dhDYb54khSrjDWw==}
+  '@rollup/rollup-linux-x64-gnu@4.34.8':
+    resolution: {integrity: sha512-8y7ED8gjxITUltTUEJLQdgpbPh1sUQ0kMTmufRF/Ns5tI9TNMNlhWtmPKKHCU0SilX+3MJkZ0zERYYGIVBYHIA==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.34.6':
-    resolution: {integrity: sha512-zmmpOQh8vXc2QITsnCiODCDGXFC8LMi64+/oPpPx5qz3pqv0s6x46ps4xoycfUiVZps5PFn1gksZzo4RGTKT+A==}
+  '@rollup/rollup-linux-x64-musl@4.34.8':
+    resolution: {integrity: sha512-SCXcP0ZpGFIe7Ge+McxY5zKxiEI5ra+GT3QRxL0pMMtxPfpyLAKleZODi1zdRHkz5/BhueUrYtYVgubqe9JBNQ==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-win32-arm64-msvc@4.34.6':
-    resolution: {integrity: sha512-3/q1qUsO/tLqGBaD4uXsB6coVGB3usxw3qyeVb59aArCgedSF66MPdgRStUd7vbZOsko/CgVaY5fo2vkvPLWiA==}
+  '@rollup/rollup-win32-arm64-msvc@4.34.8':
+    resolution: {integrity: sha512-YHYsgzZgFJzTRbth4h7Or0m5O74Yda+hLin0irAIobkLQFRQd1qWmnoVfwmKm9TXIZVAD0nZ+GEb2ICicLyCnQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.34.6':
-    resolution: {integrity: sha512-oLHxuyywc6efdKVTxvc0135zPrRdtYVjtVD5GUm55I3ODxhU/PwkQFD97z16Xzxa1Fz0AEe4W/2hzRtd+IfpOA==}
+  '@rollup/rollup-win32-ia32-msvc@4.34.8':
+    resolution: {integrity: sha512-r3NRQrXkHr4uWy5TOjTpTYojR9XmF0j/RYgKCef+Ag46FWUTltm5ziticv8LdNsDMehjJ543x/+TJAek/xBA2w==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.34.6':
-    resolution: {integrity: sha512-0PVwmgzZ8+TZ9oGBmdZoQVXflbvuwzN/HRclujpl4N/q3i+y0lqLw8n1bXA8ru3sApDjlmONaNAuYr38y1Kr9w==}
+  '@rollup/rollup-win32-x64-msvc@4.34.8':
+    resolution: {integrity: sha512-U0FaE5O1BCpZSeE6gBl3c5ObhePQSfk9vDRToMmTkbhCOgW4jqvtS5LGyQ76L1fH8sM0keRp4uDTsbjiUyjk0g==}
     cpu: [x64]
     os: [win32]
 
@@ -602,8 +602,8 @@ packages:
   '@shikijs/types@1.29.2':
     resolution: {integrity: sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==}
 
-  '@shikijs/vscode-textmate@10.0.1':
-    resolution: {integrity: sha512-fTIQwLF+Qhuws31iw7Ncl1R3HUDtGwIipiJ9iU+UsDUwMhegFcQKQHd51nZjb7CArq0MvON8rbgCGQYWHUKAdg==}
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
   '@types/argparse@1.0.38':
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
@@ -622,9 +622,6 @@ packages:
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
-
-  '@types/gensync@1.0.4':
-    resolution: {integrity: sha512-C3YYeRQWp2fmq9OryX+FoDy8nXS6scQ7dPptD8LnFDAUNcKWJjXQKDNJD3HVm+kOUsXhTOkpi69vI4EuAr95bA==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -738,8 +735,8 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
-  caniuse-lite@1.0.30001699:
-    resolution: {integrity: sha512-b+uH5BakXZ9Do9iK+CkDmctUSEqZl+SP056vc5usa0PL+ev5OHw003rZXcnjNDv3L8P5j6rwT6C0BPKSikW08w==}
+  caniuse-lite@1.0.30001700:
+    resolution: {integrity: sha512-2S6XIXwaE7K7erT8dY+kLQcpa5ms63XlRkMkReXjle+kf6c5g38vyMl+Z5y8dSxOFDhcFe+nxnn261PLxBSQsQ==}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -780,8 +777,8 @@ packages:
     engines: {node: '>=0.10'}
     hasBin: true
 
-  electron-to-chromium@1.5.99:
-    resolution: {integrity: sha512-77c/+fCyL2U+aOyqfIFi89wYLBeSTCs55xCZL0oFH0KjqsvSvyh6AdQ+UIl1vgpnQQE6g+/KK8hOIupH6VwPtg==}
+  electron-to-chromium@1.5.102:
+    resolution: {integrity: sha512-eHhqaja8tE/FNpIiBrvBjFV/SSKpyWHLvxuR9dPTdo+3V9ppdLmFB7ZZQ98qNovcngPLYIz0oOBF9P0FfZef5Q==}
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
@@ -1013,8 +1010,8 @@ packages:
     resolution: {integrity: sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==}
     engines: {node: '>=0.10.0'}
 
-  readdirp@4.1.1:
-    resolution: {integrity: sha512-h80JrZu/MHUZCyHu5ciuoI0+WxsCxzxJTILn6Fs8rxSnFPh+UVHYfeIxK1nVGugMqkfC4vJcBOYbkfkwYK0+gw==}
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
   require-from-string@2.0.2:
@@ -1026,8 +1023,8 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
-  rollup@4.34.6:
-    resolution: {integrity: sha512-wc2cBWqJgkU3Iz5oztRkQbfVkbxoz5EhnCGOrnJvnLnQ7O0WhQUYyv18qQI79O8L7DdHrrlJNeCHd4VGpnaXKQ==}
+  rollup@4.34.8:
+    resolution: {integrity: sha512-489gTVMzAYdiZHFVA/ig/iYFllCcWFHMvUHI1rpFmkoUtRlQxqh6/yiNqnYibjMZ2b/+FUQwldG+aLsEt6bglQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -1222,19 +1219,18 @@ snapshots:
 
   '@babel/compat-data@7.26.8': {}
 
-  '@babel/core@7.26.8':
+  '@babel/core@7.26.9':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/code-frame': 7.26.2
-      '@babel/generator': 7.26.8
+      '@babel/generator': 7.26.9
       '@babel/helper-compilation-targets': 7.26.5
-      '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.8)
-      '@babel/helpers': 7.26.7
-      '@babel/parser': 7.26.8
-      '@babel/template': 7.26.8
-      '@babel/traverse': 7.26.8
-      '@babel/types': 7.26.8
-      '@types/gensync': 1.0.4
+      '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.9)
+      '@babel/helpers': 7.26.9
+      '@babel/parser': 7.26.9
+      '@babel/template': 7.26.9
+      '@babel/traverse': 7.26.9
+      '@babel/types': 7.26.9
       convert-source-map: 2.0.0
       debug: 4.4.0
       gensync: 1.0.0-beta.2
@@ -1243,10 +1239,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/generator@7.26.8':
+  '@babel/generator@7.26.9':
     dependencies:
-      '@babel/parser': 7.26.8
-      '@babel/types': 7.26.8
+      '@babel/parser': 7.26.9
+      '@babel/types': 7.26.9
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 3.1.0
@@ -1261,17 +1257,17 @@ snapshots:
 
   '@babel/helper-module-imports@7.25.9':
     dependencies:
-      '@babel/traverse': 7.26.8
-      '@babel/types': 7.26.8
+      '@babel/traverse': 7.26.9
+      '@babel/types': 7.26.9
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.26.0(@babel/core@7.26.8)':
+  '@babel/helper-module-transforms@7.26.0(@babel/core@7.26.9)':
     dependencies:
-      '@babel/core': 7.26.8
+      '@babel/core': 7.26.9
       '@babel/helper-module-imports': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
-      '@babel/traverse': 7.26.8
+      '@babel/traverse': 7.26.9
     transitivePeerDependencies:
       - supports-color
 
@@ -1283,44 +1279,44 @@ snapshots:
 
   '@babel/helper-validator-option@7.25.9': {}
 
-  '@babel/helpers@7.26.7':
+  '@babel/helpers@7.26.9':
     dependencies:
-      '@babel/template': 7.26.8
-      '@babel/types': 7.26.8
+      '@babel/template': 7.26.9
+      '@babel/types': 7.26.9
 
-  '@babel/parser@7.26.8':
+  '@babel/parser@7.26.9':
     dependencies:
-      '@babel/types': 7.26.8
+      '@babel/types': 7.26.9
 
-  '@babel/plugin-transform-react-jsx-self@7.25.9(@babel/core@7.26.8)':
+  '@babel/plugin-transform-react-jsx-self@7.25.9(@babel/core@7.26.9)':
     dependencies:
-      '@babel/core': 7.26.8
+      '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-transform-react-jsx-source@7.25.9(@babel/core@7.26.8)':
+  '@babel/plugin-transform-react-jsx-source@7.25.9(@babel/core@7.26.9)':
     dependencies:
-      '@babel/core': 7.26.8
+      '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/template@7.26.8':
+  '@babel/template@7.26.9':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@babel/parser': 7.26.8
-      '@babel/types': 7.26.8
+      '@babel/parser': 7.26.9
+      '@babel/types': 7.26.9
 
-  '@babel/traverse@7.26.8':
+  '@babel/traverse@7.26.9':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@babel/generator': 7.26.8
-      '@babel/parser': 7.26.8
-      '@babel/template': 7.26.8
-      '@babel/types': 7.26.8
+      '@babel/generator': 7.26.9
+      '@babel/parser': 7.26.9
+      '@babel/template': 7.26.9
+      '@babel/types': 7.26.9
       debug: 4.4.0
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/types@7.26.8':
+  '@babel/types@7.26.9':
     dependencies:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
@@ -1439,7 +1435,7 @@ snapshots:
     dependencies:
       '@shikijs/engine-oniguruma': 1.29.2
       '@shikijs/types': 1.29.2
-      '@shikijs/vscode-textmate': 10.0.1
+      '@shikijs/vscode-textmate': 10.0.2
 
   '@jridgewell/gen-mapping@0.3.8':
     dependencies:
@@ -1564,69 +1560,69 @@ snapshots:
     dependencies:
       playwright: 1.50.1
 
-  '@rollup/pluginutils@5.1.4(rollup@4.34.6)':
+  '@rollup/pluginutils@5.1.4(rollup@4.34.8)':
     dependencies:
       '@types/estree': 1.0.6
       estree-walker: 2.0.2
       picomatch: 4.0.2
     optionalDependencies:
-      rollup: 4.34.6
+      rollup: 4.34.8
 
-  '@rollup/rollup-android-arm-eabi@4.34.6':
+  '@rollup/rollup-android-arm-eabi@4.34.8':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.34.6':
+  '@rollup/rollup-android-arm64@4.34.8':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.34.6':
+  '@rollup/rollup-darwin-arm64@4.34.8':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.34.6':
+  '@rollup/rollup-darwin-x64@4.34.8':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.34.6':
+  '@rollup/rollup-freebsd-arm64@4.34.8':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.34.6':
+  '@rollup/rollup-freebsd-x64@4.34.8':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.34.6':
+  '@rollup/rollup-linux-arm-gnueabihf@4.34.8':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.34.6':
+  '@rollup/rollup-linux-arm-musleabihf@4.34.8':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.34.6':
+  '@rollup/rollup-linux-arm64-gnu@4.34.8':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.34.6':
+  '@rollup/rollup-linux-arm64-musl@4.34.8':
     optional: true
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.34.6':
+  '@rollup/rollup-linux-loongarch64-gnu@4.34.8':
     optional: true
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.34.6':
+  '@rollup/rollup-linux-powerpc64le-gnu@4.34.8':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.34.6':
+  '@rollup/rollup-linux-riscv64-gnu@4.34.8':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.34.6':
+  '@rollup/rollup-linux-s390x-gnu@4.34.8':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.34.6':
+  '@rollup/rollup-linux-x64-gnu@4.34.8':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.34.6':
+  '@rollup/rollup-linux-x64-musl@4.34.8':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.34.6':
+  '@rollup/rollup-win32-arm64-msvc@4.34.8':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.34.6':
+  '@rollup/rollup-win32-ia32-msvc@4.34.8':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.34.6':
+  '@rollup/rollup-win32-x64-msvc@4.34.8':
     optional: true
 
   '@rushstack/node-core-library@5.11.0(@types/node@22.13.4)':
@@ -1666,41 +1662,39 @@ snapshots:
   '@shikijs/engine-oniguruma@1.29.2':
     dependencies:
       '@shikijs/types': 1.29.2
-      '@shikijs/vscode-textmate': 10.0.1
+      '@shikijs/vscode-textmate': 10.0.2
 
   '@shikijs/types@1.29.2':
     dependencies:
-      '@shikijs/vscode-textmate': 10.0.1
+      '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
-  '@shikijs/vscode-textmate@10.0.1': {}
+  '@shikijs/vscode-textmate@10.0.2': {}
 
   '@types/argparse@1.0.38': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.26.8
-      '@babel/types': 7.26.8
+      '@babel/parser': 7.26.9
+      '@babel/types': 7.26.9
       '@types/babel__generator': 7.6.8
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.20.6
 
   '@types/babel__generator@7.6.8':
     dependencies:
-      '@babel/types': 7.26.8
+      '@babel/types': 7.26.9
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.26.8
-      '@babel/types': 7.26.8
+      '@babel/parser': 7.26.9
+      '@babel/types': 7.26.9
 
   '@types/babel__traverse@7.20.6':
     dependencies:
-      '@babel/types': 7.26.8
+      '@babel/types': 7.26.9
 
   '@types/estree@1.0.6': {}
-
-  '@types/gensync@1.0.4': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -1724,9 +1718,9 @@ snapshots:
 
   '@vitejs/plugin-react@4.3.4(vite@6.1.0(@types/node@22.13.4)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0))':
     dependencies:
-      '@babel/core': 7.26.8
-      '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.8)
-      '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.8)
+      '@babel/core': 7.26.9
+      '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.9)
+      '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.9)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
       vite: 6.1.0(@types/node@22.13.4)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0)
@@ -1747,7 +1741,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.13':
     dependencies:
-      '@babel/parser': 7.26.8
+      '@babel/parser': 7.26.9
       '@vue/shared': 3.5.13
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -1828,19 +1822,19 @@ snapshots:
 
   browserslist@4.24.4:
     dependencies:
-      caniuse-lite: 1.0.30001699
-      electron-to-chromium: 1.5.99
+      caniuse-lite: 1.0.30001700
+      electron-to-chromium: 1.5.102
       node-releases: 2.0.19
       update-browserslist-db: 1.1.2(browserslist@4.24.4)
 
   buffer-from@1.1.2:
     optional: true
 
-  caniuse-lite@1.0.30001699: {}
+  caniuse-lite@1.0.30001700: {}
 
   chokidar@4.0.3:
     dependencies:
-      readdirp: 4.1.1
+      readdirp: 4.1.2
     optional: true
 
   commander@2.20.3:
@@ -1865,7 +1859,7 @@ snapshots:
   detect-libc@1.0.3:
     optional: true
 
-  electron-to-chromium@1.5.99: {}
+  electron-to-chromium@1.5.102: {}
 
   entities@4.5.0: {}
 
@@ -2088,7 +2082,7 @@ snapshots:
 
   react@19.0.0: {}
 
-  readdirp@4.1.1:
+  readdirp@4.1.2:
     optional: true
 
   require-from-string@2.0.2: {}
@@ -2099,29 +2093,29 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
-  rollup@4.34.6:
+  rollup@4.34.8:
     dependencies:
       '@types/estree': 1.0.6
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.34.6
-      '@rollup/rollup-android-arm64': 4.34.6
-      '@rollup/rollup-darwin-arm64': 4.34.6
-      '@rollup/rollup-darwin-x64': 4.34.6
-      '@rollup/rollup-freebsd-arm64': 4.34.6
-      '@rollup/rollup-freebsd-x64': 4.34.6
-      '@rollup/rollup-linux-arm-gnueabihf': 4.34.6
-      '@rollup/rollup-linux-arm-musleabihf': 4.34.6
-      '@rollup/rollup-linux-arm64-gnu': 4.34.6
-      '@rollup/rollup-linux-arm64-musl': 4.34.6
-      '@rollup/rollup-linux-loongarch64-gnu': 4.34.6
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.34.6
-      '@rollup/rollup-linux-riscv64-gnu': 4.34.6
-      '@rollup/rollup-linux-s390x-gnu': 4.34.6
-      '@rollup/rollup-linux-x64-gnu': 4.34.6
-      '@rollup/rollup-linux-x64-musl': 4.34.6
-      '@rollup/rollup-win32-arm64-msvc': 4.34.6
-      '@rollup/rollup-win32-ia32-msvc': 4.34.6
-      '@rollup/rollup-win32-x64-msvc': 4.34.6
+      '@rollup/rollup-android-arm-eabi': 4.34.8
+      '@rollup/rollup-android-arm64': 4.34.8
+      '@rollup/rollup-darwin-arm64': 4.34.8
+      '@rollup/rollup-darwin-x64': 4.34.8
+      '@rollup/rollup-freebsd-arm64': 4.34.8
+      '@rollup/rollup-freebsd-x64': 4.34.8
+      '@rollup/rollup-linux-arm-gnueabihf': 4.34.8
+      '@rollup/rollup-linux-arm-musleabihf': 4.34.8
+      '@rollup/rollup-linux-arm64-gnu': 4.34.8
+      '@rollup/rollup-linux-arm64-musl': 4.34.8
+      '@rollup/rollup-linux-loongarch64-gnu': 4.34.8
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.34.8
+      '@rollup/rollup-linux-riscv64-gnu': 4.34.8
+      '@rollup/rollup-linux-s390x-gnu': 4.34.8
+      '@rollup/rollup-linux-x64-gnu': 4.34.8
+      '@rollup/rollup-linux-x64-musl': 4.34.8
+      '@rollup/rollup-win32-arm64-msvc': 4.34.8
+      '@rollup/rollup-win32-ia32-msvc': 4.34.8
+      '@rollup/rollup-win32-x64-msvc': 4.34.8
       fsevents: 2.3.3
 
   sass@1.83.0:
@@ -2207,10 +2201,10 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite-plugin-dts@4.5.0(@types/node@22.13.4)(rollup@4.34.6)(typescript@5.7.3)(vite@6.1.0(@types/node@22.13.4)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0)):
+  vite-plugin-dts@4.5.0(@types/node@22.13.4)(rollup@4.34.8)(typescript@5.7.3)(vite@6.1.0(@types/node@22.13.4)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0)):
     dependencies:
       '@microsoft/api-extractor': 7.50.0(@types/node@22.13.4)
-      '@rollup/pluginutils': 5.1.4(rollup@4.34.6)
+      '@rollup/pluginutils': 5.1.4(rollup@4.34.8)
       '@volar/typescript': 2.4.11
       '@vue/language-core': 2.2.0(typescript@5.7.3)
       compare-versions: 6.1.1
@@ -2230,7 +2224,7 @@ snapshots:
     dependencies:
       esbuild: 0.24.2
       postcss: 8.5.2
-      rollup: 4.34.6
+      rollup: 4.34.8
     optionalDependencies:
       '@types/node': 22.13.4
       fsevents: 2.3.3

--- a/src/ayame.ts
+++ b/src/ayame.ts
@@ -239,16 +239,23 @@ class Connection {
 
   private setCodecPreferences(
     kind: 'audio' | 'video',
-    videoCapabilities: RTCRtpCapabilities,
+    codecMimeType: string,
+    capabilities: RTCRtpCapabilities,
     transceiver: RTCRtpTransceiver,
   ): void {
+    this.traceLog(`${kind} codecMimeType=`, codecMimeType)
+    // 指定されたコーデックが存在しない場合は return で返す
+    if (!capabilities.codecs.some((codec) => codec.mimeType === codecMimeType)) {
+      return
+    }
+
+    // codecPreferences が設定できない場合は return で返す
     if (typeof transceiver.setCodecPreferences !== 'function') {
       return
     }
+
     let codecs: RTCRtpCodecCapability[] = []
-    if (this.options.video.codecMimeType) {
-      codecs = getSelectedCodecs(kind, this.options.video.codecMimeType, videoCapabilities.codecs)
-    }
+    codecs = getSelectedCodecs(kind, codecMimeType, capabilities.codecs)
     this.traceLog(`${kind} codecs=`, codecs)
     transceiver.setCodecPreferences(codecs)
   }
@@ -269,28 +276,42 @@ class Connection {
         if (audioTransceiver) {
           audioTransceiver.direction = this.options.audio.direction
         }
-        // audioCodecMimeType が指定されている場合は音声コーデックの設定を試みる
-        if (this.isAudioCodecSpecified() && audioTransceiver !== null) {
-          const audioCapabilities = RTCRtpSender.getCapabilities('audio')
-          if (audioCapabilities) {
-            this.setCodecPreferences('audio', audioCapabilities, audioTransceiver)
-          }
+        const audioCapabilities = RTCRtpSender.getCapabilities('audio')
+        // コーデックが指定されていた場合は setCodecPreferences を試みる
+        if (
+          this.options.audio.enabled &&
+          this.options.audio.codecMimeType !== undefined &&
+          audioTransceiver !== null &&
+          audioCapabilities !== null
+        ) {
+          this.setCodecPreferences(
+            'audio',
+            this.options.audio.codecMimeType,
+            audioCapabilities,
+            audioTransceiver,
+          )
         }
       }
       // 基本的に受信側はコーデック指定はしないほうがいい
       // recvonly で audio が有効な場合、
-      // コーデックが指定されていた場合は setCodecPreferences を試みる
     } else if (this.options.audio.enabled) {
       const audioTransceiver = pc.addTransceiver('audio', {
         direction: this.options.audio.direction,
       })
-      // audioCodecMimeType が指定されている場合は音声コーデックの設定を試みる
-      if (this.isAudioCodecSpecified()) {
+      const audioCapabilities = RTCRtpReceiver.getCapabilities('audio')
+      // コーデックが指定されていた場合は setCodecPreferences を試みる
+      if (
+        this.options.audio.enabled &&
+        this.options.audio.codecMimeType !== undefined &&
+        audioCapabilities !== null
+      ) {
         // コーデックを指定された場合は受信出来るかどうかの確認をする
-        const audioCapabilities = RTCRtpReceiver.getCapabilities('audio')
-        if (audioCapabilities) {
-          this.setCodecPreferences('audio', audioCapabilities, audioTransceiver)
-        }
+        this.setCodecPreferences(
+          'audio',
+          this.options.audio.codecMimeType,
+          audioCapabilities,
+          audioTransceiver,
+        )
       }
     }
 
@@ -305,28 +326,42 @@ class Connection {
         if (videoTransceiver) {
           videoTransceiver.direction = this.options.video.direction
         }
-        // videoCodecMimeType が指定されている場合は映像コーデックの設定を試みる
-        if (this.isVideoCodecSpecified() && videoTransceiver !== null) {
-          const videoCapabilities = RTCRtpSender.getCapabilities('video')
-          if (videoCapabilities) {
-            this.setCodecPreferences('video', videoCapabilities, videoTransceiver)
-          }
+        const videoCapabilities = RTCRtpSender.getCapabilities('video')
+        // コーデックが指定されていた場合は setCodecPreferences を試みる
+        if (
+          this.options.video.enabled &&
+          this.options.video.codecMimeType !== undefined &&
+          videoTransceiver !== null &&
+          videoCapabilities !== null
+        ) {
+          this.setCodecPreferences(
+            'video',
+            this.options.video.codecMimeType,
+            videoCapabilities,
+            videoTransceiver,
+          )
         }
       }
       // 基本的に受信側はコーデック指定はしないほうがいい
       // recvonly で video が有効な場合、
-      // コーデックが指定されていた場合は setCodecPreferences を試みる
     } else if (this.options.video.enabled) {
       const videoTransceiver = pc.addTransceiver('video', {
         direction: this.options.video.direction,
       })
-      // videoCodecMimeType が指定されている場合は映像コーデックの設定を試みる
-      if (this.isVideoCodecSpecified()) {
-        // コーデックを指定された場合は受信出来るかどうかの確認をする
-        const videoCapabilities = RTCRtpReceiver.getCapabilities('video')
-        if (videoCapabilities) {
-          this.setCodecPreferences('video', videoCapabilities, videoTransceiver)
-        }
+      const videoCapabilities = RTCRtpReceiver.getCapabilities('video')
+      // コーデックが指定されていた場合は setCodecPreferences を試みる
+      if (
+        this.options.video.enabled &&
+        this.options.video.codecMimeType !== undefined &&
+        videoTransceiver !== null &&
+        videoCapabilities !== null
+      ) {
+        this.setCodecPreferences(
+          'video',
+          this.options.video.codecMimeType,
+          videoCapabilities,
+          videoTransceiver,
+        )
       }
     }
 

--- a/src/ayame.ts
+++ b/src/ayame.ts
@@ -468,35 +468,6 @@ class Connection {
     if (!this.pc) {
       return
     }
-    if (this.options.audio.enabled && this.options.audio.direction !== 'recvonly') {
-      this.pc.addTransceiver('audio', { direction: this.options.audio.direction })
-      const audioTransceiver = this.pc.addTransceiver('audio', {
-        direction: this.options.audio.direction,
-      })
-      // audioCodecMimeType が指定されている場合は音声コーデックの設定を試みる
-      if (this.isAudioCodecSpecified()) {
-        // コーデックを指定された場合は受信出来るかどうかの確認をする
-        const audioCapabilities = RTCRtpReceiver.getCapabilities('audio')
-        if (audioCapabilities) {
-          this.setCodecPreferences('audio', audioCapabilities, audioTransceiver)
-        }
-      }
-    }
-
-    if (this.options.video.enabled && this.options.video.direction !== 'recvonly') {
-      this.pc.addTransceiver('video', { direction: this.options.video.direction })
-      const videoTransceiver = this.pc.addTransceiver('video', {
-        direction: this.options.video.direction,
-      })
-      // audioCodecMimeType が指定されている場合は音声コーデックの設定を試みる
-      if (this.isVideoCodecSpecified()) {
-        // コーデックを指定された場合は受信出来るかどうかの確認をする
-        const videoCapabilities = RTCRtpReceiver.getCapabilities('video')
-        if (videoCapabilities) {
-          this.setCodecPreferences('video', videoCapabilities, videoTransceiver)
-        }
-      }
-    }
 
     const offer: any = await this.pc.createOffer({
       offerToReceiveAudio:

--- a/src/ayame.ts
+++ b/src/ayame.ts
@@ -242,19 +242,15 @@ class Connection {
     videoCapabilities: RTCRtpCapabilities,
     transceiver: RTCRtpTransceiver,
   ): void {
-    if (typeof transceiver.setCodecPreferences !== 'undefined') {
+    if (typeof transceiver.setCodecPreferences !== 'function') {
       return
     }
-    let videoCodecs: RTCRtpCodecCapability[] = []
+    let codecs: RTCRtpCodecCapability[] = []
     if (this.options.video.codecMimeType) {
-      videoCodecs = getSelectedCodecs(
-        kind,
-        this.options.video.codecMimeType,
-        videoCapabilities.codecs,
-      )
+      codecs = getSelectedCodecs(kind, this.options.video.codecMimeType, videoCapabilities.codecs)
     }
-    this.traceLog(`${kind} codecs=`, videoCodecs)
-    transceiver.setCodecPreferences(videoCodecs)
+    this.traceLog(`${kind} codecs=`, codecs)
+    transceiver.setCodecPreferences(codecs)
   }
 
   private createPeerConnection(): void {
@@ -270,6 +266,9 @@ class Connection {
         const audioTrack = audioTracks[0]
         const audioSender = pc.addTrack(audioTrack, this.stream)
         const audioTransceiver = this.getTransceiver(pc, audioSender)
+        if (audioTransceiver) {
+          audioTransceiver.direction = this.options.audio.direction
+        }
         // audioCodecMimeType が指定されている場合は音声コーデックの設定を試みる
         if (this.isAudioCodecSpecified() && audioTransceiver !== null) {
           const audioCapabilities = RTCRtpSender.getCapabilities('audio')
@@ -282,7 +281,9 @@ class Connection {
       // recvonly で audio が有効な場合、
       // コーデックが指定されていた場合は setCodecPreferences を試みる
     } else if (this.options.audio.enabled) {
-      const audioTransceiver = pc.addTransceiver('audio', { direction: 'recvonly' })
+      const audioTransceiver = pc.addTransceiver('audio', {
+        direction: this.options.audio.direction,
+      })
       // audioCodecMimeType が指定されている場合は音声コーデックの設定を試みる
       if (this.isAudioCodecSpecified()) {
         // コーデックを指定された場合は受信出来るかどうかの確認をする
@@ -301,6 +302,9 @@ class Connection {
         const videoTrack = videoTracks[0]
         const videoSender = pc.addTrack(videoTrack, this.stream)
         const videoTransceiver = this.getTransceiver(pc, videoSender)
+        if (videoTransceiver) {
+          videoTransceiver.direction = this.options.video.direction
+        }
         // videoCodecMimeType が指定されている場合は映像コーデックの設定を試みる
         if (this.isVideoCodecSpecified() && videoTransceiver !== null) {
           const videoCapabilities = RTCRtpSender.getCapabilities('video')
@@ -313,7 +317,9 @@ class Connection {
       // recvonly で video が有効な場合、
       // コーデックが指定されていた場合は setCodecPreferences を試みる
     } else if (this.options.video.enabled) {
-      const videoTransceiver = pc.addTransceiver('video', { direction: 'recvonly' })
+      const videoTransceiver = pc.addTransceiver('video', {
+        direction: this.options.video.direction,
+      })
       // videoCodecMimeType が指定されている場合は映像コーデックの設定を試みる
       if (this.isVideoCodecSpecified()) {
         // コーデックを指定された場合は受信出来るかどうかの確認をする
@@ -462,14 +468,36 @@ class Connection {
     if (!this.pc) {
       return
     }
-    if (browser() === 'safari') {
-      if (this.options.video.enabled && this.options.video.direction === 'sendrecv') {
-        this.pc.addTransceiver('video', { direction: 'recvonly' })
-      }
-      if (this.options.audio.enabled && this.options.audio.direction === 'sendrecv') {
-        this.pc.addTransceiver('audio', { direction: 'recvonly' })
+    if (this.options.audio.enabled && this.options.audio.direction !== 'recvonly') {
+      this.pc.addTransceiver('audio', { direction: this.options.audio.direction })
+      const audioTransceiver = this.pc.addTransceiver('audio', {
+        direction: this.options.audio.direction,
+      })
+      // audioCodecMimeType が指定されている場合は音声コーデックの設定を試みる
+      if (this.isAudioCodecSpecified()) {
+        // コーデックを指定された場合は受信出来るかどうかの確認をする
+        const audioCapabilities = RTCRtpReceiver.getCapabilities('audio')
+        if (audioCapabilities) {
+          this.setCodecPreferences('audio', audioCapabilities, audioTransceiver)
+        }
       }
     }
+
+    if (this.options.video.enabled && this.options.video.direction !== 'recvonly') {
+      this.pc.addTransceiver('video', { direction: this.options.video.direction })
+      const videoTransceiver = this.pc.addTransceiver('video', {
+        direction: this.options.video.direction,
+      })
+      // audioCodecMimeType が指定されている場合は音声コーデックの設定を試みる
+      if (this.isVideoCodecSpecified()) {
+        // コーデックを指定された場合は受信出来るかどうかの確認をする
+        const videoCapabilities = RTCRtpReceiver.getCapabilities('video')
+        if (videoCapabilities) {
+          this.setCodecPreferences('video', videoCapabilities, videoTransceiver)
+        }
+      }
+    }
+
     const offer: any = await this.pc.createOffer({
       offerToReceiveAudio:
         this.options.audio.enabled && this.options.audio.direction !== 'sendonly',
@@ -556,10 +584,11 @@ class Connection {
 
   private getTransceiver(pc: RTCPeerConnection, track: any): RTCRtpTransceiver | null {
     let transceiver = null
-    // biome-ignore lint/complexity/noForEach: <explanation>
-    pc.getTransceivers().forEach((t: RTCRtpTransceiver) => {
-      if (t.sender === track || t.receiver === track) transceiver = t
-    })
+    for (const t of pc.getTransceivers()) {
+      if (t.sender === track || t.receiver === track) {
+        transceiver = t
+      }
+    }
     if (!transceiver) {
       throw new Error('invalid transceiver')
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -55,7 +55,7 @@ export function traceLog(title: string, value?: string | Record<string, any>): v
 export const getSelectedCodecs = (
   kind: 'audio' | 'video',
   selectedCodecMimeType: string,
-  codecs: RTCRtpCodec[],
+  codecs: RTCRtpCodecCapability[],
 ): RTCRtpCodecCapability[] => {
   const filteredCodecs = codecs.filter((c) => {
     const codecMimeType = c.mimeType.toLowerCase()

--- a/tests/codec.test.mts
+++ b/tests/codec.test.mts
@@ -1,0 +1,74 @@
+import { expect, test } from '@playwright/test'
+
+const codecs = [
+  // 音声は Opus のみ
+  // 映像は H.264/H.265 は Playwright ではサポートされていない
+  { audioCodec: 'audio/opus', videoCodec: 'video/AV1' },
+  { audioCodec: 'audio/opus', videoCodec: 'video/VP8' },
+  { audioCodec: 'audio/opus', videoCodec: 'video/VP9' },
+]
+
+test.describe
+  .parallel('コーデックテスト', () => {
+    for (const { audioCodec, videoCodec } of codecs) {
+      test(`DevTools with ${audioCodec} and ${videoCodec}`, async ({ browser }) => {
+        const sendrecv1 = await browser.newPage()
+        const sendrecv2 = await browser.newPage()
+
+        await sendrecv1.goto('http://localhost:9000/')
+        await sendrecv2.goto('http://localhost:9000/')
+
+        // RoodID を取得
+        const roomId1 = await sendrecv1.evaluate(() => {
+          const roomIdElement = document.querySelector(
+            '[data-testid="room-id"]',
+          ) as HTMLInputElement
+          return roomIdElement.value
+        })
+        const roomId2 = await sendrecv2.evaluate(() => {
+          const roomIdElement = document.querySelector(
+            '[data-testid="room-id"]',
+          ) as HTMLInputElement
+          return roomIdElement.value
+        })
+        const roomIdSuffix = crypto.randomUUID()
+
+        // RoomId を再設定
+        await sendrecv1.fill('[data-testid="room-id"]', `${roomId1}-${roomIdSuffix}`)
+        await sendrecv2.fill('[data-testid="room-id"]', `${roomId2}-${roomIdSuffix}`)
+
+        // 音声コーデックを設定
+        await sendrecv1.selectOption('[data-testid="audio-codec-mime-type"]', audioCodec)
+
+        // 映像コーデックを設定
+        await sendrecv1.selectOption('[data-testid="video-codec-mime-type"]', videoCodec)
+
+        // ボタンが表示されるまで待つ
+        await sendrecv1.waitForSelector('[data-testid="connect"]', { state: 'visible' })
+        await sendrecv2.waitForSelector('[data-testid="connect"]', { state: 'visible' })
+
+        await sendrecv1.click('[data-testid="connect"]')
+        await sendrecv2.click('[data-testid="connect"]')
+
+        // data-connection-state が connected になるまで待つ
+        await expect(sendrecv1.locator('[data-testid="connection-state"]')).toHaveAttribute(
+          'data-connection-state',
+          'connected',
+          { timeout: 10000 },
+        )
+
+        // もう一方のページも connected になるまで待つ
+        await expect(sendrecv2.locator('[data-testid="connection-state"]')).toHaveAttribute(
+          'data-connection-state',
+          'connected',
+          { timeout: 10000 },
+        )
+
+        await sendrecv1.click('[data-testid="disconnect"]')
+        await sendrecv2.click('[data-testid="disconnect"]')
+
+        await sendrecv1.close()
+        await sendrecv2.close()
+      })
+    }
+  })


### PR DESCRIPTION
This pull request includes several updates to GitHub Actions workflows, codec preference settings, and test additions. The most important changes include renaming jobs in workflow files, adding codec preferences, and introducing new tests for codec configurations.

### Workflow Updates:
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL6-R14): Renamed `build` job to `ci_job` and updated node versions to include "23".
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L10-R10): Renamed `build` job to `deploy_job` and updated dependencies accordingly. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L10-R10) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L44-R44)
* [`.github/workflows/e2e-test.yml`](diffhunk://#diff-5cc2c864012004f60ee3f9078fa1c4a8721c6b841e386c57f12bea58b692e6e2L15-R20): Renamed `e2e-test` job to `e2e_test_job`, updated node versions to include "23", and adjusted matrix variables. [[1]](diffhunk://#diff-5cc2c864012004f60ee3f9078fa1c4a8721c6b841e386c57f12bea58b692e6e2L15-R20) [[2]](diffhunk://#diff-5cc2c864012004f60ee3f9078fa1c4a8721c6b841e386c57f12bea58b692e6e2L31-R39)

### Codec Preference Settings:
* [`src/ayame.ts`](diffhunk://#diff-1107b4499173f5c79d8d99adbce0d1ce81efb5b962193a69bf2faef5349f43b4L242-R260): Updated `setCodecPreferences` method to accept codec MIME type and capabilities, and added logic to handle codec preferences for both audio and video tracks. [[1]](diffhunk://#diff-1107b4499173f5c79d8d99adbce0d1ce81efb5b962193a69bf2faef5349f43b4L242-R260) [[2]](diffhunk://#diff-1107b4499173f5c79d8d99adbce0d1ce81efb5b962193a69bf2faef5349f43b4L273-R314) [[3]](diffhunk://#diff-1107b4499173f5c79d8d99adbce0d1ce81efb5b962193a69bf2faef5349f43b4L304-R364) [[4]](diffhunk://#diff-1107b4499173f5c79d8d99adbce0d1ce81efb5b962193a69bf2faef5349f43b4L465-R506) [[5]](diffhunk://#diff-1107b4499173f5c79d8d99adbce0d1ce81efb5b962193a69bf2faef5349f43b4L559-R597)
* [`src/utils.ts`](diffhunk://#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351L58-R58): Adjusted `getSelectedCodecs` function to work with `RTCRtpCodecCapability`.

### Test Additions:
* [`tests/codec.test.mts`](diffhunk://#diff-52fc9938369bf60cc1e1fbd9f6ffd500769a3c42f558fa0bf261bfab2d5830d6R1-R74): Added new Playwright tests to verify codec configurations for audio and video.

### Documentation Updates:
* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R18-R49): Updated to reflect new codec preference settings and other recent changes.

### Component Updates:
* [`devtools/src/components/AudioCodecMimeType.tsx`](diffhunk://#diff-ec04d4118632d4bb3c8349881d4dda6de9ea30eb9a38d6020f84030bc0979bceL26-R26): Added `data-testid` attribute to the audio codec MIME type select element.
* [`devtools/src/components/VideoCodecMimeType.tsx`](diffhunk://#diff-f799e3eb13c563a664a0ae3b8cbae602e815a9b41b0ff3868b5f768fc6220362L26-R26): Added `data-testid` attribute to the video codec MIME type select element.