### PR TITLE
0001 disconnect 時に remoteStream をリセットする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,8 @@
   - @voluntas
 - [ADD] DevTools に解像度を設定するオプションを追加
   - @voluntas
+- [FIX] disconnect 後の再接続で addstream が発火しない問題を修正する
+  - @voluntas
 
 ## 2025.1.1
 

--- a/devtools/src/components/RemoteVideo.tsx
+++ b/devtools/src/components/RemoteVideo.tsx
@@ -13,7 +13,13 @@ const RemoteVideo = (): VNode => {
   });
 
   return (
-    <video ref={videoRef} autoPlay playsInline class="w-[400px] h-[300px] border border-red-500">
+    <video
+      ref={videoRef}
+      autoPlay
+      playsInline
+      data-testid="remote-video"
+      class="w-[400px] h-[300px] border border-red-500"
+    >
       <track kind="captions" srcLang="ja" label="日本語" default />
     </video>
   );

--- a/issues/closed/0001-bug-fix-remote-stream-reset-on-disconnect.md
+++ b/issues/closed/0001-bug-fix-remote-stream-reset-on-disconnect.md
@@ -2,6 +2,7 @@
 
 - Priority: High
 - Created: 2026-05-19
+- Completed: 2026-05-20
 - Model: Composer 2.5
 - Branch: feature/fix-remote-stream-reset-on-disconnect
 
@@ -109,6 +110,10 @@ AGENTS.md に従い、**モック・スタブは使用しない**。
 ### 手動確認（E2E 環境が無い場合）
 
 Ayame Labo 等で DevTools を 2 タブ開き、上記 1〜3 を実施。2 回目以降もリモート映像が表示されること。
+
+## 解決方法
+
+`src/ayame.ts` の `disconnect()` で `this.remoteStream = null` を追加した。`createPeerConnection()` の先頭で `this.pc` が存在する場合に `this.remoteStream = null` をリセットし、glare 時の PeerConnection 差し替え経路に対応した。`devtools/src/components/RemoteVideo.tsx` に `data-testid="remote-video"` を追加し、`tests/devtools.test.ts` に disconnect → connect の再接続 E2E を追加した。glare 経路の旧 PC ハンドラ解除は issue 0005 で対応予定。
 
 ## 解決方法（実装手順）
 

--- a/src/ayame.ts
+++ b/src/ayame.ts
@@ -167,6 +167,7 @@ class Connection {
     this.isExistUser = false;
     this.dataChannels = [];
     this.connectionState = "new";
+    this.remoteStream = null;
   }
 
   /**
@@ -323,6 +324,9 @@ class Connection {
   }
 
   private createPeerConnection(): void {
+    if (this.pc) {
+      this.remoteStream = null;
+    }
     this.traceLog("RTCConfiguration=>", this.pcConfig);
 
     const pc = new RTCPeerConnection(this.pcConfig);

--- a/tests/devtools.test.ts
+++ b/tests/devtools.test.ts
@@ -57,6 +57,37 @@ test("DevTools のテスト", async ({ browser }) => {
     },
   );
 
+  const waitForRemoteVideo = async (page: typeof sendrecv1): Promise<void> => {
+    await page.waitForFunction(
+      () => {
+        const video = document.querySelector('[data-testid="remote-video"]');
+        if (!(video instanceof HTMLVideoElement)) {
+          return false;
+        }
+        const stream = video.srcObject;
+        return stream instanceof MediaStream && stream.getVideoTracks().length > 0;
+      },
+      { timeout: 10_000 },
+    );
+  };
+
+  // タブ 2 でリモート映像が表示されることを確認
+  await waitForRemoteVideo(sendrecv2);
+
+  await sendrecv1.click('[data-testid="disconnect"]');
+
+  // タブ 1 で再接続
+  await sendrecv1.click('[data-testid="connect"]');
+
+  await expect(sendrecv1.locator('[data-testid="connection-state"]')).toHaveAttribute(
+    "data-connection-state",
+    "connected",
+    { timeout: 10_000 },
+  );
+
+  // 再接続後もタブ 2 でリモート映像が表示される
+  await waitForRemoteVideo(sendrecv2);
+
   await sendrecv1.click('[data-testid="disconnect"]');
   await sendrecv2.click('[data-testid="disconnect"]');
 


### PR DESCRIPTION
## 概要

同一 `Connection` インスタンスで disconnect 後に connect した際、`addstream` が再発火しない問題を修正する。

## 変更内容

- `disconnect()` で `remoteStream` を null にリセットする
- `createPeerConnection()` 先頭で PeerConnection 差し替え時に `remoteStream` をリセットする
- DevTools の remote video に `data-testid="remote-video"` を追加する
- disconnect → connect の再接続 E2E を `tests/devtools.test.ts` に追加する

## 完了条件

- [x] 同一 `Connection` で disconnect → connect を繰り返しても、毎回 `addstream` が発火する
- [x] 既存 E2E（`tests/devtools.test.ts`, `tests/codec.test.ts`）が通る
- [x] `CHANGES.md` の `## develop` に本修正を `[FIX]` で記載済み
- [ ] glare 相当の完了条件は issue 0005 マージ後に確認（本 PR では `remoteStream` リセットのみ）

## 関連 issue

- issues/closed/0001-bug-fix-remote-stream-reset-on-disconnect.md