### PR TITLE
0002 bye 受信時にセッションを解放する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,8 @@
   - @voluntas
 - [FIX] disconnect 後の再接続で addstream が発火しない問題を修正する
   - @voluntas
+- [FIX] bye 受信時にセッションを解放し disconnect コールバックを発火する
+  - @voluntas
 
 ## 2025.1.1
 

--- a/issues/closed/0002-bug-fix-bye-session-cleanup.md
+++ b/issues/closed/0002-bug-fix-bye-session-cleanup.md
@@ -2,6 +2,7 @@
 
 - Priority: High
 - Created: 2026-05-19
+- Completed: 2026-05-20
 - Model: Composer 2.5
 - Branch: feature/fix-bye-session-cleanup
 

--- a/src/ayame.ts
+++ b/src/ayame.ts
@@ -45,6 +45,7 @@ function isSignalingMessage(value: unknown): value is AyameSignalingMessage {
 
 interface AyameCallbacks {
   addstream: (event: AyameAddStreamEvent) => void;
+  /** ピア終了の通知。セッション解放は disconnect で行う。bye コールバック内で disconnect() を呼び出してはならない。 */
   bye: (event: MessageEvent) => void;
   connect: () => void;
   datachannel: (dataChannel: RTCDataChannel) => void;
@@ -234,6 +235,13 @@ class Connection {
                 });
               } else if (message.type === "bye") {
                 this.callbacks.bye(event);
+                void this.disconnect()
+                  .then(() => {
+                    this.callbacks.disconnect({ reason: "BYE" });
+                  })
+                  .catch(() => {
+                    this.callbacks.disconnect({ reason: "BYE" });
+                  });
                 resolve();
                 return;
               } else if (message.type === "accept") {

--- a/tests/bye.test.ts
+++ b/tests/bye.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "@playwright/test";
+
+test("bye 受信後に再接続できる", async ({ browser }) => {
+  const peer1 = await browser.newPage();
+  const peer2 = await browser.newPage();
+
+  await peer1.goto("http://localhost:9000/");
+  await peer2.goto("http://localhost:9000/");
+
+  const roomId1 = await peer1.evaluate(() => {
+    const roomIdElement = document.querySelector('[data-testid="room-id"]')!;
+    return (roomIdElement as HTMLInputElement).value;
+  });
+  const roomId2 = await peer2.evaluate(() => {
+    const roomIdElement = document.querySelector('[data-testid="room-id"]')!;
+    return (roomIdElement as HTMLInputElement).value;
+  });
+  const roomIdSuffix = crypto.randomUUID();
+
+  await peer1.fill('[data-testid="room-id"]', `${roomId1}-${roomIdSuffix}`);
+  await peer2.fill('[data-testid="room-id"]', `${roomId2}-${roomIdSuffix}`);
+
+  await peer1.waitForSelector('[data-testid="connect"]', { state: "visible" });
+  await peer2.waitForSelector('[data-testid="connect"]', { state: "visible" });
+
+  await peer1.click('[data-testid="connect"]');
+  await peer2.click('[data-testid="connect"]');
+
+  await expect(peer1.locator('[data-testid="connection-state"]')).toHaveAttribute(
+    "data-connection-state",
+    "connected",
+    { timeout: 10_000 },
+  );
+  await expect(peer2.locator('[data-testid="connection-state"]')).toHaveAttribute(
+    "data-connection-state",
+    "connected",
+    { timeout: 10_000 },
+  );
+
+  await peer1.click('[data-testid="disconnect"]');
+
+  // ピア 2 は bye 経由で切断され、再度 connect できる
+  await peer2.click('[data-testid="connect"]');
+
+  await expect(peer2.locator('[data-testid="connection-state"]')).toHaveAttribute(
+    "data-connection-state",
+    "connected",
+    { timeout: 10_000 },
+  );
+
+  await peer1.click('[data-testid="disconnect"]');
+  await peer2.click('[data-testid="disconnect"]');
+
+  await peer1.close();
+  await peer2.close();
+});


### PR DESCRIPTION
## 概要

シグナリングサーバから type: bye を受信したとき、セッションを解放し disconnect コールバックを発火する。

## 変更内容

- bye 分岐で disconnect() 後に callbacks.disconnect({ reason: "BYE" }) を呼ぶ
- bye コールバックの JSDoc を追加する
- tests/bye.test.ts に E2E を追加する

## 完了条件

- [x] bye 受信後、セッションが解放される
- [x] on("disconnect") が 1 回発火し、reason が "BYE" である
- [x] on("bye") も従来どおり呼ばれる
- [x] E2E で再現・確認できる
- [x] CHANGES.md に [FIX] 記載済み

## 関連 issue

- issues/closed/0002-bug-fix-bye-session-cleanup.md
