### PR TITLE
0003 公開 defaultOptions の共有ミュータブル化を解消する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,9 +41,13 @@
   - @voluntas
 - [ADD] DevTools に解像度を設定するオプションを追加
   - @voluntas
+- [ADD] createDefaultOptions 関数を追加する
+  - @voluntas
 - [FIX] disconnect 後の再接続で addstream が発火しない問題を修正する
   - @voluntas
 - [FIX] bye 受信時にセッションを解放し disconnect コールバックを発火する
+  - @voluntas
+- [FIX] DevTools で defaultOptions を直接書き換えていた問題を修正する
   - @voluntas
 
 ## 2025.1.1

--- a/devtools/src/components/ConnectButton.tsx
+++ b/devtools/src/components/ConnectButton.tsx
@@ -1,7 +1,7 @@
 import type { VNode } from "preact";
-import { createConnection, defaultOptions } from "@open-ayame/ayame-web-sdk";
+import { createConnection, createDefaultOptions } from "@open-ayame/ayame-web-sdk";
 // eslint-disable-next-line no-duplicate-imports -- consistent-type-specifier-style との競合を回避
-import type { AyameAddStreamEvent } from "@open-ayame/ayame-web-sdk";
+import type { AyameAddStreamEvent, ConnectionOptions } from "@open-ayame/ayame-web-sdk";
 import {
   audioCodecMimeType,
   audioDirection,
@@ -22,14 +22,25 @@ import {
 
 const ConnectButton = (): VNode => {
   const handleClick = async (): Promise<void> => {
-    const options = defaultOptions;
-    options.audio.enabled = audioEnabled.value;
-    options.audio.direction = audioDirection.value;
-    options.audio.codecMimeType = audioCodecMimeType.value;
-    options.video.enabled = videoEnabled.value;
-    options.video.direction = videoDirection.value;
-    options.video.codecMimeType = videoCodecMimeType.value;
-    options.signalingKey = signalingKey.value;
+    const base = createDefaultOptions();
+    const options: ConnectionOptions = {
+      ...base,
+      audio: {
+        ...base.audio,
+        codecMimeType:
+          audioCodecMimeType.value === "undefined" ? undefined : audioCodecMimeType.value,
+        direction: audioDirection.value,
+        enabled: audioEnabled.value,
+      },
+      signalingKey: signalingKey.value || undefined,
+      video: {
+        ...base.video,
+        codecMimeType:
+          videoCodecMimeType.value === "undefined" ? undefined : videoCodecMimeType.value,
+        direction: videoDirection.value,
+        enabled: videoEnabled.value,
+      },
+    };
 
     const conn = createConnection(signalingUrl.value, roomId.value, options, debug.value);
 

--- a/issues/closed/0003-bug-fix-default-options-shared-mutation.md
+++ b/issues/closed/0003-bug-fix-default-options-shared-mutation.md
@@ -2,6 +2,7 @@
 
 - Priority: High
 - Created: 2026-05-19
+- Completed: 2026-05-20
 - Model: Composer 2.5
 - Branch: feature/fix-default-options-shared-mutation
 
@@ -83,6 +84,10 @@ DevTools で Connect → 設定変更 → 再度 Connect。2 回目が 1 回目�
 ### E2E（任意・0006 と連携）
 
 2 回 Connect 間で room ID 以外の設定を変え、2 回目に反映されることを確認。
+
+## 解決方法
+
+`createDefaultOptions()` を `src/ayame.ts` に追加し、`createConnection` のデフォルト引数を `createDefaultOptions()` に変更した。`devtools/src/components/ConnectButton.tsx` では毎回 `createDefaultOptions()` から新規 `ConnectionOptions` を組み立てるようにした。
 
 ## 解決方法（実装手順）
 

--- a/src/ayame.ts
+++ b/src/ayame.ts
@@ -801,6 +801,27 @@ class Connection {
 export default Connection;
 
 /**
+ * Ayame Connection のデフォルトのオプションを新規生成します。
+ * 呼び出しごとに新しいオブジェクトを返します。
+ */
+export const createDefaultOptions = (): ConnectionOptions => ({
+  audio: {
+    codecMimeType: undefined,
+    direction: "sendrecv",
+    enabled: true,
+  },
+  clientId: crypto.randomUUID(),
+  iceServers: [],
+  signalingKey: undefined,
+  standalone: undefined,
+  video: {
+    codecMimeType: undefined,
+    direction: "sendrecv",
+    enabled: true,
+  },
+});
+
+/**
  * Ayame Connection のデフォルトのオプションです。
  */
 export const defaultOptions: ConnectionOptions = {
@@ -834,7 +855,7 @@ export const connection = (
 export const createConnection = (
   signalingUrl: string,
   roomId: string,
-  options: ConnectionOptions = defaultOptions,
+  options: ConnectionOptions = createDefaultOptions(),
   debug = false,
   isRelay = false,
 ): Connection => new Connection(signalingUrl, roomId, options, debug, isRelay);


### PR DESCRIPTION
## 概要

export された defaultOptions の共有ミュータブル化を解消し、createDefaultOptions を追加する。

## 変更内容

- createDefaultOptions() を追加する
- createConnection のデフォルト引数を createDefaultOptions() に変更する
- DevTools ConnectButton で毎回新規 options を組み立てる

## 完了条件

- [x] 連続 Connect で設定が漏れない
- [x] createDefaultOptions() は呼び出しごとに新規オブジェクトを返す
- [x] DevTools が defaultOptions を直接書き換えない
- [x] build / typecheck / lint が通る
- [x] CHANGES.md に [ADD] と [FIX] を記載済み

## 関連 issue

- issues/closed/0003-bug-fix-default-options-shared-mutation.md
