### PR TITLE
0007 DevTools の useEffect cleanup が登録されない問題を修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,8 @@
   - @voluntas
 - [FIX] DevTools で defaultOptions を直接書き換えていた問題を修正する
   - @voluntas
+- [FIX] DevTools の useEffect cleanup が登録されない問題を修正する
+  - @voluntas
 
 ## 2025.1.1
 

--- a/devtools/src/App.tsx
+++ b/devtools/src/App.tsx
@@ -1,4 +1,5 @@
 import type { VNode } from "preact";
+import { useEffect } from "preact/hooks";
 import AyameVersion from "./components/AyameWebSdkVersion";
 import ConnectButton from "./components/ConnectButton";
 import ConnectionSettings from "./components/ConnectionSettings";
@@ -11,8 +12,10 @@ import RemoteVideo from "./components/RemoteVideo";
 import { setSettingsFromUrl } from "./signals";
 
 const App = (): VNode => {
-  const params = new URLSearchParams(globalThis.location.search);
-  setSettingsFromUrl(params);
+  useEffect(() => {
+    const params = new URLSearchParams(globalThis.location.search);
+    setSettingsFromUrl(params);
+  }, []);
 
   return (
     <div class="p-4">

--- a/devtools/src/components/AudioInputDevice.tsx
+++ b/devtools/src/components/AudioInputDevice.tsx
@@ -6,41 +6,51 @@ const AudioInputDevice = (): VNode => {
   const [devices, setDevices] = useState<MediaDeviceInfo[]>([]);
 
   useEffect(() => {
-    const getDevices = async () => {
-      const permissionStatus = await navigator.permissions.query({
+    let cancelled = false;
+    let permissionStatus: PermissionStatus | undefined;
+
+    const handlePermissionChange = async (): Promise<void> => {
+      if (cancelled || !permissionStatus) {
+        return;
+      }
+      if (permissionStatus.state === "granted") {
+        const deviceList = await navigator.mediaDevices.enumerateDevices();
+        if (cancelled) {
+          return;
+        }
+        const audioInputDevices = deviceList.filter((device) => device.kind === "audioinput");
+        setDevices(audioInputDevices);
+        if (
+          audioInputDevices.length > 0 &&
+          !audioInputDevices.some((d) => d.deviceId === audioInputDeviceId.value)
+        ) {
+          const defaultDevice = audioInputDevices.find((d) => d.deviceId === "default");
+          audioInputDeviceId.value = defaultDevice?.deviceId ?? audioInputDevices[0].deviceId;
+        }
+      } else {
+        setDevices([]);
+      }
+    };
+
+    void (async () => {
+      permissionStatus = await navigator.permissions.query({
         name: "microphone" as PermissionName,
       });
-
-      const handlePermissionChange = async (): Promise<void> => {
-        if (permissionStatus.state === "granted") {
-          const deviceList = await navigator.mediaDevices.enumerateDevices();
-          const audioInputDevices = deviceList.filter((device) => device.kind === "audioinput");
-          setDevices(audioInputDevices);
-          // 現在の値がデバイスリストに存在しない場合、default または最初のデバイスを選択
-          if (
-            audioInputDevices.length > 0 &&
-            !audioInputDevices.some((d) => d.deviceId === audioInputDeviceId.value)
-          ) {
-            const defaultDevice = audioInputDevices.find((d) => d.deviceId === "default");
-            audioInputDeviceId.value = defaultDevice?.deviceId ?? audioInputDevices[0].deviceId;
-          }
-        } else {
-          setDevices([]);
-        }
+      if (cancelled) {
+        return;
+      }
+      await handlePermissionChange();
+      permissionStatus.onchange = () => {
+        void handlePermissionChange();
       };
+    })();
 
-      // 初期状態の処理
-      void handlePermissionChange();
-
-      // 権限変更の監視
-      permissionStatus.onchange = handlePermissionChange;
-
-      return (): void => {
-        // クリーンアップ
+    return () => {
+      cancelled = true;
+      if (permissionStatus) {
         permissionStatus.onchange = null;
-      };
+      }
     };
-    void getDevices();
   }, []);
 
   return (

--- a/devtools/src/components/AudioOutputDevice.tsx
+++ b/devtools/src/components/AudioOutputDevice.tsx
@@ -6,41 +6,51 @@ const AudioOutputDevice = (): VNode => {
   const [devices, setDevices] = useState<MediaDeviceInfo[]>([]);
 
   useEffect(() => {
-    const getDevices = async () => {
-      const permissionStatus = await navigator.permissions.query({
+    let cancelled = false;
+    let permissionStatus: PermissionStatus | undefined;
+
+    const handlePermissionChange = async (): Promise<void> => {
+      if (cancelled || !permissionStatus) {
+        return;
+      }
+      if (permissionStatus.state === "granted") {
+        const deviceList = await navigator.mediaDevices.enumerateDevices();
+        if (cancelled) {
+          return;
+        }
+        const audioOutputDevices = deviceList.filter((device) => device.kind === "audiooutput");
+        setDevices(audioOutputDevices);
+        if (
+          audioOutputDevices.length > 0 &&
+          !audioOutputDevices.some((d) => d.deviceId === audioOutputDeviceId.value)
+        ) {
+          const defaultDevice = audioOutputDevices.find((d) => d.deviceId === "default");
+          audioOutputDeviceId.value = defaultDevice?.deviceId ?? audioOutputDevices[0].deviceId;
+        }
+      } else {
+        setDevices([]);
+      }
+    };
+
+    void (async () => {
+      permissionStatus = await navigator.permissions.query({
         name: "microphone" as PermissionName,
       });
-
-      const handlePermissionChange = async (): Promise<void> => {
-        if (permissionStatus.state === "granted") {
-          const deviceList = await navigator.mediaDevices.enumerateDevices();
-          const audioOutputDevices = deviceList.filter((device) => device.kind === "audiooutput");
-          setDevices(audioOutputDevices);
-          // 現在の値がデバイスリストに存在しない場合、default または最初のデバイスを選択
-          if (
-            audioOutputDevices.length > 0 &&
-            !audioOutputDevices.some((d) => d.deviceId === audioOutputDeviceId.value)
-          ) {
-            const defaultDevice = audioOutputDevices.find((d) => d.deviceId === "default");
-            audioOutputDeviceId.value = defaultDevice?.deviceId ?? audioOutputDevices[0].deviceId;
-          }
-        } else {
-          setDevices([]);
-        }
+      if (cancelled) {
+        return;
+      }
+      await handlePermissionChange();
+      permissionStatus.onchange = () => {
+        void handlePermissionChange();
       };
+    })();
 
-      // 初期状態の処理
-      void handlePermissionChange();
-
-      // 権限変更の監視
-      permissionStatus.onchange = handlePermissionChange;
-
-      return (): void => {
-        // クリーンアップ
+    return () => {
+      cancelled = true;
+      if (permissionStatus) {
         permissionStatus.onchange = null;
-      };
+      }
     };
-    void getDevices();
   }, []);
 
   return (

--- a/devtools/src/components/CameraPermissionState.tsx
+++ b/devtools/src/components/CameraPermissionState.tsx
@@ -1,8 +1,37 @@
 import type { VNode } from "preact";
-import { cameraPermissionState, setCameraPermissionState } from "../signals";
+import { useSignalEffect } from "@preact/signals";
+import { cameraPermissionState } from "../signals";
 
-void setCameraPermissionState();
+const CameraPermissionState = (): VNode => {
+  useSignalEffect(() => {
+    let cancelled = false;
+    let permissionStatus: PermissionStatus | undefined;
 
-const CameraPermissionState = (): VNode => <>{cameraPermissionState.value}</>;
+    void (async () => {
+      permissionStatus = await navigator.permissions.query({
+        name: "camera" as PermissionName,
+      });
+      if (cancelled) {
+        return;
+      }
+      cameraPermissionState.value = permissionStatus.state;
+      permissionStatus.onchange = () => {
+        if (cancelled || !permissionStatus) {
+          return;
+        }
+        cameraPermissionState.value = permissionStatus.state;
+      };
+    })();
+
+    return () => {
+      cancelled = true;
+      if (permissionStatus) {
+        permissionStatus.onchange = null;
+      }
+    };
+  });
+
+  return <>{cameraPermissionState.value}</>;
+};
 
 export default CameraPermissionState;

--- a/devtools/src/components/MicrophonePermissionState.tsx
+++ b/devtools/src/components/MicrophonePermissionState.tsx
@@ -1,8 +1,37 @@
 import type { VNode } from "preact";
-import { microphonePermissionState, setMicrophonePermissionState } from "../signals";
+import { useSignalEffect } from "@preact/signals";
+import { microphonePermissionState } from "../signals";
 
-void setMicrophonePermissionState();
+const MicrophonePermissionState = (): VNode => {
+  useSignalEffect(() => {
+    let cancelled = false;
+    let permissionStatus: PermissionStatus | undefined;
 
-const MicrophonePermissionState = (): VNode => <>{microphonePermissionState.value}</>;
+    void (async () => {
+      permissionStatus = await navigator.permissions.query({
+        name: "microphone" as PermissionName,
+      });
+      if (cancelled) {
+        return;
+      }
+      microphonePermissionState.value = permissionStatus.state;
+      permissionStatus.onchange = () => {
+        if (cancelled || !permissionStatus) {
+          return;
+        }
+        microphonePermissionState.value = permissionStatus.state;
+      };
+    })();
+
+    return () => {
+      cancelled = true;
+      if (permissionStatus) {
+        permissionStatus.onchange = null;
+      }
+    };
+  });
+
+  return <>{microphonePermissionState.value}</>;
+};
 
 export default MicrophonePermissionState;

--- a/devtools/src/components/RequestMediaPermissionButton.tsx
+++ b/devtools/src/components/RequestMediaPermissionButton.tsx
@@ -13,49 +13,55 @@ const RequestMediaPermissionButton = ({
   const isPermissionsGranted = useSignal(false);
 
   useEffect(() => {
+    const permissionsToCheck: PermissionStatus[] = [];
+    let cancelled = false;
+
     const checkPermissions = async (): Promise<void> => {
-      // チェックすべきパーミッションを入れる
-      const PermissionsToCheck = [];
-
-      // 音声が有効だったらパーミッションのチェックをする
       if (audioEnabled.value) {
-        const microphonePermission = await navigator.permissions.query({
-          name: "microphone" as PermissionName,
-        });
-        PermissionsToCheck.push(microphonePermission);
-        microphonePermission.onchange = (): void => {
-          // パーミッションが granted でなければボタンを有効にする
-          isPermissionsGranted.value = microphonePermission.state === "granted";
-        };
+        const mic = await navigator.permissions.query({ name: "microphone" as PermissionName });
+        if (cancelled) {
+          return;
+        }
+        permissionsToCheck.push(mic);
       }
-      // 映像が有効だったらパーミッションのチェックをする
       if (videoEnabled.value) {
-        const cameraPermission = await navigator.permissions.query({
-          name: "camera" as PermissionName,
-        });
-        PermissionsToCheck.push(cameraPermission);
-        cameraPermission.onchange = (): void => {
-          // パーミッションが granted でなければボタンを有効にする
-          isPermissionsGranted.value = cameraPermission.state === "granted";
+        const cam = await navigator.permissions.query({ name: "camera" as PermissionName });
+        if (cancelled) {
+          return;
+        }
+        permissionsToCheck.push(cam);
+      }
+
+      if (cancelled) {
+        return;
+      }
+      for (const p of permissionsToCheck) {
+        p.onchange = () => {
+          if (cancelled) {
+            return;
+          }
+          isPermissionsGranted.value = permissionsToCheck.every((pp) => pp.state === "granted");
         };
       }
 
-      // パーミッションをチェックする必要がなかったら終了
-      if (PermissionsToCheck.length === 0) {
+      if (permissionsToCheck.length === 0) {
         isPermissionsGranted.value = true;
         return;
       }
-
-      // パーミッションのチェックをする
-      const allGranted = PermissionsToCheck.every((permission) => permission.state === "granted");
-      isPermissionsGranted.value = allGranted;
+      isPermissionsGranted.value = permissionsToCheck.every((p) => p.state === "granted");
     };
     void checkPermissions();
-  }, []);
+
+    return () => {
+      cancelled = true;
+      for (const p of permissionsToCheck) {
+        p.onchange = null;
+      }
+    };
+  }, [audioEnabled.value, videoEnabled.value]);
 
   const handleClick = async (): Promise<void> => {
     try {
-      // ちゃんと有効にしているデバイスのパーミッションだけを取りに行く
       let videoConstraints: boolean | MediaTrackConstraints = videoEnabled.value;
       if (videoEnabled.value && videoResolution.value && videoResolution.value !== "undefined") {
         const [width, height] = videoResolution.value.split("x").map(Number);
@@ -74,9 +80,7 @@ const RequestMediaPermissionButton = ({
         audio: audioEnabled.value,
         video: videoConstraints,
       };
-      // メディアデバイスのパーミッションを取りに行く
       const stream = await navigator.mediaDevices.getUserMedia(constraints);
-      // ストリームを停止する
       for (const track of stream.getTracks()) {
         track.stop();
       }
@@ -85,7 +89,6 @@ const RequestMediaPermissionButton = ({
     }
   };
 
-  // <permission> を利用した microphone/camera の権限取得
   if ("HTMLPermissionElement" in globalThis) {
     // @ts-expect-error HTMLPermissionElement を認識しないため
     return <permission type="microphone camera" />;

--- a/devtools/src/components/VideoInputDevice.tsx
+++ b/devtools/src/components/VideoInputDevice.tsx
@@ -6,41 +6,51 @@ const VideoInputDevice = (): VNode => {
   const [devices, setDevices] = useState<MediaDeviceInfo[]>([]);
 
   useEffect(() => {
-    const getDevices = async () => {
-      const permissionStatus = await navigator.permissions.query({
+    let cancelled = false;
+    let permissionStatus: PermissionStatus | undefined;
+
+    const handlePermissionChange = async (): Promise<void> => {
+      if (cancelled || !permissionStatus) {
+        return;
+      }
+      if (permissionStatus.state === "granted") {
+        const deviceList = await navigator.mediaDevices.enumerateDevices();
+        if (cancelled) {
+          return;
+        }
+        const videoInputDevices = deviceList.filter((device) => device.kind === "videoinput");
+        setDevices(videoInputDevices);
+        if (
+          videoInputDevices.length > 0 &&
+          !videoInputDevices.some((d) => d.deviceId === videoInputDeviceId.value)
+        ) {
+          const defaultDevice = videoInputDevices.find((d) => d.deviceId === "default");
+          videoInputDeviceId.value = defaultDevice?.deviceId ?? videoInputDevices[0].deviceId;
+        }
+      } else {
+        setDevices([]);
+      }
+    };
+
+    void (async () => {
+      permissionStatus = await navigator.permissions.query({
         name: "camera" as PermissionName,
       });
-
-      const handlePermissionChange = async (): Promise<void> => {
-        if (permissionStatus.state === "granted") {
-          const deviceList = await navigator.mediaDevices.enumerateDevices();
-          const videoInputDevices = deviceList.filter((device) => device.kind === "videoinput");
-          setDevices(videoInputDevices);
-          // 現在の値がデバイスリストに存在しない場合、default または最初のデバイスを選択
-          if (
-            videoInputDevices.length > 0 &&
-            !videoInputDevices.some((d) => d.deviceId === videoInputDeviceId.value)
-          ) {
-            const defaultDevice = videoInputDevices.find((d) => d.deviceId === "default");
-            videoInputDeviceId.value = defaultDevice?.deviceId ?? videoInputDevices[0].deviceId;
-          }
-        } else {
-          setDevices([]);
-        }
+      if (cancelled) {
+        return;
+      }
+      await handlePermissionChange();
+      permissionStatus.onchange = () => {
+        void handlePermissionChange();
       };
+    })();
 
-      // 初期状態の処理
-      void handlePermissionChange();
-
-      // 権限変更の監視
-      permissionStatus.onchange = handlePermissionChange;
-
-      return (): void => {
-        // クリーンアップ
+    return () => {
+      cancelled = true;
+      if (permissionStatus) {
         permissionStatus.onchange = null;
-      };
+      }
     };
-    void getDevices();
   }, []);
 
   return (

--- a/issues/closed/0007-bug-fix-devtools-useeffect-cleanup.md
+++ b/issues/closed/0007-bug-fix-devtools-useeffect-cleanup.md
@@ -2,6 +2,7 @@
 
 - Priority: High
 - Created: 2026-05-19
+- Completed: 2026-05-20
 - Model: Composer 2.5
 - Branch: feature/fix-devtools-useeffect-cleanup
 


### PR DESCRIPTION
## 概要

DevTools の Preact コンポーネントで useEffect の cleanup が正しく登録されない問題を修正する。

## 変更内容

- デバイス 3 コンポーネントの async useEffect パターンを修正する
- RequestMediaPermissionButton に cleanup と audio/video 依存を追加する
- 権限表示コンポーネントを useSignalEffect に移す
- App.tsx の URL 初期化を useEffect に移す

## 完了条件

- [x] useEffect cleanup が同期 return で登録される
- [x] モジュール import 時の副作用を削除する
- [x] lint / E2E が通る
- [x] CHANGES.md に [FIX] 記載済み

## 関連 issue

- issues/closed/0007-bug-fix-devtools-useeffect-cleanup.md
