### PR TITLE
0004 DevTools を Preact Signals のベストプラクティスに沿って再構成する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,10 @@
   - @voluntas
 - [ADD] createDefaultOptions 関数を追加する
   - @voluntas
+- [UPDATE] DevTools を Preact Signals のベストプラクティスに沿って再構成する
+  - connectionOptions / mediaConstraints の computed 化
+  - ayameSession モデルによる接続フローの集約
+  - @voluntas
 - [FIX] disconnect 後の再接続で addstream が発火しない問題を修正する
   - @voluntas
 - [FIX] bye 受信時にセッションを解放し disconnect コールバックを発火する
@@ -71,6 +75,8 @@
 
 ### misc
 
+- [UPDATE] DevTools から未使用の preact-iso 依存を削除する
+  - @voluntas
 - [ADD] 再接続・bye・コーデックネゴの E2E テストを追加する
   - @voluntas
 - [ADD] tests/reconnect.test.ts を追加する

--- a/devtools/package.json
+++ b/devtools/package.json
@@ -9,8 +9,7 @@
   "dependencies": {
     "@open-ayame/ayame-web-sdk": "workspace:*",
     "@preact/signals": "2.9.0",
-    "preact": "10.29.1",
-    "preact-iso": "2.11.1"
+    "preact": "10.29.1"
   },
   "devDependencies": {
     "@preact/preset-vite": "2.10.5",

--- a/devtools/src/components/AudioCodecMimeType.tsx
+++ b/devtools/src/components/AudioCodecMimeType.tsx
@@ -1,31 +1,29 @@
 import type { VNode } from "preact";
-import { useSignal, useSignalEffect } from "@preact/signals";
+import { useComputed } from "@preact/signals";
 import { getAvailableCodecs } from "@open-ayame/ayame-web-sdk";
 import { audioCodecMimeType, audioDirection } from "../signals";
 
 const AudioCodecMimeType = (): VNode => {
-  const codecs = useSignal<string[]>([]);
-
-  useSignalEffect(() => {
-    const mimeTypes = getAvailableCodecs(
+  const codecs = useComputed(() =>
+    getAvailableCodecs(
       "audio",
       audioDirection.value === "sendrecv" || audioDirection.value === "sendonly"
         ? "sender"
         : "receiver",
-    );
-    codecs.value = mimeTypes;
-  });
+    ),
+  );
 
   return (
     <select
       onChange={(e) => {
-        audioCodecMimeType.value = (e.target as HTMLSelectElement).value;
+        const value = (e.target as HTMLSelectElement).value;
+        audioCodecMimeType.value = value === "" ? null : value;
       }}
-      value={audioCodecMimeType.value}
+      value={audioCodecMimeType.value ?? ""}
       data-testid="audio-codec-mime-type"
       class="px-2 py-1 border border-gray-300 rounded"
     >
-      <option value="undefined">未指定</option>
+      <option value="">未指定</option>
       {codecs.value.map((mimeType) => (
         <option key={mimeType} value={mimeType}>
           {mimeType}

--- a/devtools/src/components/AyameWebSdkVersion.tsx
+++ b/devtools/src/components/AyameWebSdkVersion.tsx
@@ -1,8 +1,5 @@
 import type { VNode } from "preact";
 import { version } from "@open-ayame/ayame-web-sdk";
-import { ayameVersion } from "../signals";
-
-ayameVersion.value = version();
 
 const AyameVersion = (): VNode => <span data-testid="ayame-web-sdk-version">{version()}</span>;
 

--- a/devtools/src/components/ConnectButton.tsx
+++ b/devtools/src/components/ConnectButton.tsx
@@ -1,120 +1,17 @@
 import type { VNode } from "preact";
-import { createConnection, createDefaultOptions } from "@open-ayame/ayame-web-sdk";
-// eslint-disable-next-line no-duplicate-imports -- consistent-type-specifier-style との競合を回避
-import type { AyameAddStreamEvent, ConnectionOptions } from "@open-ayame/ayame-web-sdk";
-import {
-  audioCodecMimeType,
-  audioDirection,
-  audioEnabled,
-  ayameConnection,
-  ayameConnectionState,
-  debug,
-  localMediaStream,
-  remoteMediaStream,
-  roomId,
-  signalingKey,
-  signalingUrl,
-  videoCodecMimeType,
-  videoDirection,
-  videoEnabled,
-  videoResolution,
-} from "../signals";
+import { connectionOptions } from "../connectionOptions";
+import { canConnect, connectSession, isConnecting } from "../models/ayameSession";
 
 const ConnectButton = (): VNode => {
-  const handleClick = async (): Promise<void> => {
-    const base = createDefaultOptions();
-    const options: ConnectionOptions = {
-      ...base,
-      audio: {
-        ...base.audio,
-        codecMimeType:
-          audioCodecMimeType.value === "undefined" ? undefined : audioCodecMimeType.value,
-        direction: audioDirection.value,
-        enabled: audioEnabled.value,
-      },
-      signalingKey: signalingKey.value || undefined,
-      video: {
-        ...base.video,
-        codecMimeType:
-          videoCodecMimeType.value === "undefined" ? undefined : videoCodecMimeType.value,
-        direction: videoDirection.value,
-        enabled: videoEnabled.value,
-      },
-    };
-
-    const conn = createConnection(signalingUrl.value, roomId.value, options, debug.value);
-
-    let localStream: MediaStream | null = null;
-
-    if (
-      (audioEnabled.value && audioDirection.value !== "recvonly") ||
-      (videoEnabled.value && videoDirection.value !== "recvonly")
-    ) {
-      let videoConstraints: boolean | MediaTrackConstraints = videoEnabled.value;
-      if (videoEnabled.value && videoResolution.value && videoResolution.value !== "undefined") {
-        const [width, height] = videoResolution.value.split("x").map(Number);
-        if (width && height) {
-          videoConstraints = {
-            height: {
-              ideal: height,
-            },
-            width: {
-              ideal: width,
-            },
-          };
-        }
-      }
-      localStream = await navigator.mediaDevices.getUserMedia({
-        audio: audioEnabled.value,
-        video: videoConstraints,
-      });
-      localMediaStream.value = localStream;
-    }
-
-    conn.on("addstream", (event: AyameAddStreamEvent) => {
-      remoteMediaStream.value = event.stream;
-    });
-
-    conn.on("open", () => {
-      const pc = conn.peerConnection;
-      if (!pc) {
-        return;
-      }
-      pc.onconnectionstatechange = (): void => {
-        ayameConnectionState.value = pc.connectionState;
-      };
-      window.__ayameDevtoolsPeerConnection = pc;
-    });
-
-    // 切断時にローカルとリモートのメディアストリームを停止する
-    conn.on("disconnect", () => {
-      // この関数内で取得した localStream を停止する
-      // Store を経由しないようにする
-      if (localStream) {
-        for (const track of localStream.getTracks()) {
-          track.stop();
-        }
-      }
-
-      localMediaStream.value = null;
-      remoteMediaStream.value = null;
-      ayameConnection.value = null;
-      window.__ayameDevtoolsPeerConnection = null;
-    });
-
-    await conn.connect(localStream);
-
-    ayameConnection.value = conn;
-  };
-
   return (
     <button
       data-testid="connect"
       type="button"
+      disabled={!canConnect.value || isConnecting.value}
       onClick={(): void => {
-        void handleClick();
+        void connectSession(connectionOptions.value);
       }}
-      class="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+      class="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 disabled:bg-gray-400 disabled:cursor-not-allowed"
     >
       Connect
     </button>

--- a/devtools/src/components/DisconnectButton.tsx
+++ b/devtools/src/components/DisconnectButton.tsx
@@ -1,37 +1,17 @@
 import type { VNode } from "preact";
-import { ayameConnection, localMediaStream, remoteMediaStream } from "../signals";
+import { ayameConnection } from "../signals";
+import { disconnectSession, isConnecting } from "../models/ayameSession";
 
 const DisconnectButton = (): VNode => {
-  const handleClick = async (): Promise<void> => {
-    const conn = ayameConnection.value;
-    if (!conn) {
-      return;
-    }
-
-    const stream = localMediaStream.value;
-    if (stream) {
-      for (const track of stream.getTracks()) {
-        track.stop();
-      }
-    }
-
-    await conn.disconnect();
-
-    localMediaStream.value = null;
-    remoteMediaStream.value = null;
-
-    // AyameConnection を null にする
-    ayameConnection.value = null;
-  };
-
   return (
     <button
       data-testid="disconnect"
       type="button"
+      disabled={isConnecting.value}
       onClick={(): void => {
-        void handleClick();
+        void disconnectSession();
       }}
-      class="px-4 py-2 bg-red-500 text-white rounded hover:bg-red-600"
+      class="px-4 py-2 bg-red-500 text-white rounded hover:bg-red-600 disabled:bg-gray-400 disabled:cursor-not-allowed"
     >
       Disconnect
     </button>

--- a/devtools/src/components/RequestMediaPermissionButton.tsx
+++ b/devtools/src/components/RequestMediaPermissionButton.tsx
@@ -1,7 +1,8 @@
 import type { VNode } from "preact";
 import { useSignal } from "@preact/signals";
 import { useEffect } from "preact/hooks";
-import { audioEnabled, videoEnabled, videoResolution } from "../signals";
+import { mediaConstraints } from "../connectionOptions";
+import { audioEnabled, videoEnabled } from "../signals";
 
 interface Props {
   buttonText?: string;
@@ -62,25 +63,7 @@ const RequestMediaPermissionButton = ({
 
   const handleClick = async (): Promise<void> => {
     try {
-      let videoConstraints: boolean | MediaTrackConstraints = videoEnabled.value;
-      if (videoEnabled.value && videoResolution.value && videoResolution.value !== "undefined") {
-        const [width, height] = videoResolution.value.split("x").map(Number);
-        if (width && height) {
-          videoConstraints = {
-            height: {
-              ideal: height,
-            },
-            width: {
-              ideal: width,
-            },
-          };
-        }
-      }
-      const constraints = {
-        audio: audioEnabled.value,
-        video: videoConstraints,
-      };
-      const stream = await navigator.mediaDevices.getUserMedia(constraints);
+      const stream = await navigator.mediaDevices.getUserMedia(mediaConstraints.value);
       for (const track of stream.getTracks()) {
         track.stop();
       }

--- a/devtools/src/components/VideoCodecMimeType.tsx
+++ b/devtools/src/components/VideoCodecMimeType.tsx
@@ -1,31 +1,29 @@
 import type { VNode } from "preact";
-import { useSignal, useSignalEffect } from "@preact/signals";
+import { useComputed } from "@preact/signals";
 import { getAvailableCodecs } from "@open-ayame/ayame-web-sdk";
 import { videoCodecMimeType, videoDirection } from "../signals";
 
 const VideoCodecMimeType = (): VNode => {
-  const codecs = useSignal<string[]>([]);
-
-  useSignalEffect(() => {
-    const mimeTypes = getAvailableCodecs(
+  const codecs = useComputed(() =>
+    getAvailableCodecs(
       "video",
       videoDirection.value === "sendrecv" || videoDirection.value === "sendonly"
         ? "sender"
         : "receiver",
-    );
-    codecs.value = mimeTypes;
-  });
+    ),
+  );
 
   return (
     <select
       onChange={(e) => {
-        videoCodecMimeType.value = (e.target as HTMLSelectElement).value;
+        const value = (e.target as HTMLSelectElement).value;
+        videoCodecMimeType.value = value === "" ? null : value;
       }}
-      value={videoCodecMimeType.value}
+      value={videoCodecMimeType.value ?? ""}
       data-testid="video-codec-mime-type"
       class="px-2 py-1 border border-gray-300 rounded"
     >
-      <option value="undefined">未指定</option>
+      <option value="">未指定</option>
       {codecs.value.map((mimeType) => (
         <option key={mimeType} value={mimeType}>
           {mimeType}

--- a/devtools/src/connectionOptions.ts
+++ b/devtools/src/connectionOptions.ts
@@ -1,0 +1,76 @@
+import { computed } from "@preact/signals";
+import { createDefaultOptions } from "@open-ayame/ayame-web-sdk";
+import type { ConnectionOptions } from "@open-ayame/ayame-web-sdk";
+import {
+  audioCodecMimeType,
+  audioDirection,
+  audioEnabled,
+  audioInputDeviceId,
+  clientId,
+  signalingKey,
+  standalone,
+  videoCodecMimeType,
+  videoDirection,
+  videoEnabled,
+  videoInputDeviceId,
+  videoResolution,
+} from "./signals";
+
+const resolveDeviceId = (deviceId: string): string | undefined =>
+  deviceId === "default" ? undefined : deviceId;
+
+const buildVideoConstraints = (): boolean | MediaTrackConstraints => {
+  if (!videoEnabled.value) {
+    return false;
+  }
+  const deviceId = resolveDeviceId(videoInputDeviceId.value);
+  let constraints: MediaTrackConstraints = {};
+  if (deviceId !== undefined) {
+    constraints.deviceId = { exact: deviceId };
+  }
+  if (videoResolution.value && videoResolution.value !== "undefined") {
+    const [width, height] = videoResolution.value.split("x").map(Number);
+    if (width && height) {
+      constraints = {
+        ...constraints,
+        height: { ideal: height },
+        width: { ideal: width },
+      };
+    }
+  }
+  return Object.keys(constraints).length > 0 ? constraints : true;
+};
+
+export const connectionOptions = computed(
+  (): ConnectionOptions => ({
+    ...createDefaultOptions(),
+    clientId: clientId.value,
+    iceServers: [],
+    standalone: standalone.value || undefined,
+    signalingKey: signalingKey.value || undefined,
+    audio: {
+      codecMimeType: audioCodecMimeType.value ?? undefined,
+      direction: audioDirection.value,
+      enabled: audioEnabled.value,
+    },
+    video: {
+      codecMimeType: videoCodecMimeType.value ?? undefined,
+      direction: videoDirection.value,
+      enabled: videoEnabled.value,
+    },
+  }),
+);
+
+export const mediaConstraints = computed((): MediaStreamConstraints => {
+  const audioDeviceId = resolveDeviceId(audioInputDeviceId.value);
+  const audioConstraints: boolean | MediaTrackConstraints = audioEnabled.value
+    ? audioDeviceId === undefined
+      ? true
+      : { deviceId: { exact: audioDeviceId } }
+    : false;
+
+  return {
+    audio: audioConstraints,
+    video: buildVideoConstraints(),
+  };
+});

--- a/devtools/src/main.tsx
+++ b/devtools/src/main.tsx
@@ -1,3 +1,4 @@
+import "preact/debug";
 import { render } from "preact";
 import App from "./App";
 import "./index.css"; // eslint-disable-line import/no-unassigned-import -- CSS import

--- a/devtools/src/models/ayameSession.ts
+++ b/devtools/src/models/ayameSession.ts
@@ -1,0 +1,104 @@
+import { batch, computed, signal } from "@preact/signals";
+import { createConnection } from "@open-ayame/ayame-web-sdk";
+import type { AyameAddStreamEvent, ConnectionOptions } from "@open-ayame/ayame-web-sdk";
+import { mediaConstraints } from "../connectionOptions";
+import {
+  ayameConnection,
+  ayameConnectionState,
+  debug,
+  localMediaStream,
+  remoteMediaStream,
+  roomId,
+  signalingUrl,
+} from "../signals";
+
+export const isConnecting = signal(false);
+
+export const canConnect = computed(
+  (): boolean => !isConnecting.value && ayameConnection.value === null,
+);
+
+const clearLocalMedia = (stream: MediaStream | null): void => {
+  if (!stream) {
+    return;
+  }
+  for (const track of stream.getTracks()) {
+    track.stop();
+  }
+};
+
+const resetSessionSignals = (): void => {
+  localMediaStream.value = null;
+  remoteMediaStream.value = null;
+  ayameConnection.value = null;
+  window.__ayameDevtoolsPeerConnection = null;
+};
+
+export const disconnectSession = async (): Promise<void> => {
+  const conn = ayameConnection.value;
+  if (!conn) {
+    return;
+  }
+
+  clearLocalMedia(localMediaStream.value);
+  await conn.disconnect("USER-DISCONNECT");
+  resetSessionSignals();
+};
+
+export const connectSession = async (options: ConnectionOptions): Promise<void> => {
+  if (isConnecting.value) {
+    return;
+  }
+
+  batch(() => {
+    isConnecting.value = true;
+  });
+
+  let localStream: MediaStream | null = null;
+
+  try {
+    if (ayameConnection.value) {
+      await disconnectSession();
+    }
+
+    const conn = createConnection(signalingUrl.value, roomId.value, options, debug.value);
+    const constraints = mediaConstraints.value;
+
+    if (
+      (constraints.audio !== false && constraints.audio !== undefined) ||
+      (constraints.video !== false && constraints.video !== undefined)
+    ) {
+      localStream = await navigator.mediaDevices.getUserMedia(constraints);
+      localMediaStream.value = localStream;
+    }
+
+    conn.on("addstream", (event: AyameAddStreamEvent) => {
+      remoteMediaStream.value = event.stream;
+    });
+
+    conn.on("open", () => {
+      const pc = conn.peerConnection;
+      if (!pc) {
+        return;
+      }
+      pc.onconnectionstatechange = (): void => {
+        ayameConnectionState.value = pc.connectionState;
+      };
+      window.__ayameDevtoolsPeerConnection = pc;
+    });
+
+    conn.on("disconnect", () => {
+      clearLocalMedia(localStream);
+      resetSessionSignals();
+    });
+
+    await conn.connect(localStream);
+    ayameConnection.value = conn;
+  } catch (error) {
+    clearLocalMedia(localStream);
+    resetSessionSignals();
+    throw error;
+  } finally {
+    isConnecting.value = false;
+  }
+};

--- a/devtools/src/signals.ts
+++ b/devtools/src/signals.ts
@@ -6,7 +6,6 @@ function isDirection(value: string | null): value is Direction {
 }
 
 // Ayame signals
-export const ayameVersion = signal("");
 export const ayameConnection = signal<Connection | null>(null);
 export const ayameConnectionState = signal<RTCPeerConnectionState>("new");
 
@@ -26,11 +25,11 @@ export const videoInputDeviceId = signal("default");
 // Settings signals
 export const audioEnabled = signal(true);
 export const audioDirection = signal<Direction>("sendrecv");
-export const audioCodecMimeType = signal("undefined");
+export const audioCodecMimeType = signal<string | null>(null);
 
 export const videoEnabled = signal(true);
 export const videoDirection = signal<Direction>("sendrecv");
-export const videoCodecMimeType = signal("undefined");
+export const videoCodecMimeType = signal<string | null>(null);
 export const videoResolution = signal("");
 
 export const signalingUrl = signal(import.meta.env.VITE_AYAME_SIGNALING_URL || "");
@@ -75,15 +74,20 @@ export const generateUrlParams = (): string => {
 
   params.set("audio", audioEnabled.value.toString());
   params.set("audioDirection", audioDirection.value);
-  params.set("audioCodecMimeType", audioCodecMimeType.value);
+  if (audioCodecMimeType.value) {
+    params.set("audioCodecMimeType", audioCodecMimeType.value);
+  }
 
   params.set("video", videoEnabled.value.toString());
   params.set("videoDirection", videoDirection.value);
-  params.set("videoCodecMimeType", videoCodecMimeType.value);
+  if (videoCodecMimeType.value) {
+    params.set("videoCodecMimeType", videoCodecMimeType.value);
+  }
   params.set("videoResolution", videoResolution.value);
 
   params.set("signalingUrl", signalingUrl.value);
   params.set("roomId", roomId.value);
+  params.set("clientId", clientId.value);
   params.set("signalingKey", signalingKey.value);
   params.set("debug", debug.value.toString());
   params.set("standalone", standalone.value.toString());
@@ -95,12 +99,16 @@ export const setSettingsFromUrl = (params: URLSearchParams): void => {
   audioEnabled.value = params.get("audio") !== "false";
   const audioDir = params.get("audioDirection");
   audioDirection.value = isDirection(audioDir) ? audioDir : "sendrecv";
-  audioCodecMimeType.value = params.get("audioCodecMimeType") ?? "undefined";
+  const audioCodec = params.get("audioCodecMimeType");
+  audioCodecMimeType.value =
+    audioCodec === null || audioCodec === "" || audioCodec === "undefined" ? null : audioCodec;
 
   videoEnabled.value = params.get("video") !== "false";
   const videoDir = params.get("videoDirection");
   videoDirection.value = isDirection(videoDir) ? videoDir : "sendrecv";
-  videoCodecMimeType.value = params.get("videoCodecMimeType") ?? "undefined";
+  const videoCodec = params.get("videoCodecMimeType");
+  videoCodecMimeType.value =
+    videoCodec === null || videoCodec === "" || videoCodec === "undefined" ? null : videoCodec;
   videoResolution.value = params.get("videoResolution") ?? "";
 
   // 項目がなかった場合は今ある値をそのまま利用する

--- a/issues/closed/0004-refactor-devtools-preact-signals-architecture.md
+++ b/issues/closed/0004-refactor-devtools-preact-signals-architecture.md
@@ -2,6 +2,7 @@
 
 - Priority: Medium
 - Created: 2026-05-19
+- Completed: 2026-05-20
 - Model: Composer 2.5
 - Branch: feature/refactor-devtools-preact-signals-architecture
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,9 +44,6 @@ importers:
       preact:
         specifier: 10.29.1
         version: 10.29.1
-      preact-iso:
-        specifier: 2.11.1
-        version: 2.11.1(preact-render-to-string@6.6.4(preact@10.29.1))(preact@10.29.1)
     devDependencies:
       '@preact/preset-vite':
         specifier: 2.10.5
@@ -1569,17 +1566,6 @@ packages:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  preact-iso@2.11.1:
-    resolution: {integrity: sha512-rLy0RmzP/hrDjnFdnEblxFgKtzUj4njkHrpGJBGS7S4QuYw1zv0lA38qsWpeAAB10JAz/hF2CsHrLen9ufCtbw==}
-    peerDependencies:
-      preact: '>=10 || >= 11.0.0-0'
-      preact-render-to-string: '>=6.4.0'
-
-  preact-render-to-string@6.6.4:
-    resolution: {integrity: sha512-Bn6eQZ5SQ5loVEcC/mZmKT7HzO5Z/+vYzxfE/W2N468oSoNMJVdFGApF0GyXq0lDthuyXKTmtZ8k20NpYjr6Rw==}
-    peerDependencies:
-      preact: '>=10 || >= 11.0.0-0'
-
   preact@10.29.1:
     resolution: {integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==}
 
@@ -3031,15 +3017,6 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
-
-  preact-iso@2.11.1(preact-render-to-string@6.6.4(preact@10.29.1))(preact@10.29.1):
-    dependencies:
-      preact: 10.29.1
-      preact-render-to-string: 6.6.4(preact@10.29.1)
-
-  preact-render-to-string@6.6.4(preact@10.29.1):
-    dependencies:
-      preact: 10.29.1
 
   preact@10.29.1: {}
 


### PR DESCRIPTION
## 概要

DevTools を Preact Signals の推奨パターンに沿って再構成する。

## 変更内容

- connectionOptions / mediaConstraints の computed 化
- ayameSession モデルによる接続フロー集約
- canConnect / isConnecting による二重 Connect 防止
- codec 未指定を null に変更
- preact-iso 削除

## 関連 issue

- issues/closed/0004-refactor-devtools-preact-signals-architecture.md
